### PR TITLE
removed GODEBUG env in the hybrid sample config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apigee/apigee-remote-service-envoy
 
-go 1.13
+go 1.14
 
 // replace github.com/apigee/apigee-remote-service-golib => ../apigee-remote-service-golib
 

--- a/samples/istio/hybrid-apigee-remote-service-envoy.yaml
+++ b/samples/istio/hybrid-apigee-remote-service-envoy.yaml
@@ -49,9 +49,6 @@ spec:
       - name: apigee-remote-service-envoy
         image: "google/apigee-envoy-adapter:v1.0.0"
         imagePullPolicy: IfNotPresent
-        env:
-        - name: GODEBUG # value must be 0, as apigee does not support http 2
-          value: http2client=0
         ports:
         - containerPort: 5000
         livenessProbe:


### PR DESCRIPTION
Now that the gcp managed proxies work with an http2 client ([issue-33](https://github.com/apigee/apigee-remote-service-cli/issues/33) in -cli repo), the GODEBUG env is removed from the related config.

Note: go.mod has been updated to use go version 1.14.