### PR TITLE
added timeout for access log streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apigee/apigee-remote-service-envoy
 go 1.15
 
 require (
-	github.com/apigee/apigee-remote-service-golib v1.2.0
+	github.com/apigee/apigee-remote-service-golib v1.2.1-0.20201014193308-d793914cce47
 	github.com/envoyproxy/go-control-plane v0.9.6
 	github.com/gogo/googleapis v1.4.0
 	github.com/golang/protobuf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apigee/apigee-remote-service-golib v1.2.0 h1:hKDmddTYjPKFrlWm46UNXbn3+XJHjv2VE2TtyChAQ7o=
-github.com/apigee/apigee-remote-service-golib v1.2.0/go.mod h1:J/2GDsnbdp7dyVWCTlmVs6+Tz7VWIo1F9yoZvBhvwe0=
+github.com/apigee/apigee-remote-service-golib v1.2.1-0.20201014193308-d793914cce47 h1:5RgidjjktvkdCIhm8I7D8WbLbEGJKG5wQtk0mwBgZ7k=
+github.com/apigee/apigee-remote-service-golib v1.2.1-0.20201014193308-d793914cce47/go.mod h1:J/2GDsnbdp7dyVWCTlmVs6+Tz7VWIo1F9yoZvBhvwe0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -78,6 +78,7 @@ github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELB
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.6 h1:GgblEiDzxf5ajlAZY4aC8xp7DwkrGfauFNMGdB2bBv0=
 github.com/envoyproxy/go-control-plane v0.9.6/go.mod h1:GFqM7v0B62MraO4PWRedIbhThr/Rf7ev6aHOOPXeaDA=
+github.com/envoyproxy/go-control-plane v0.9.7 h1:EARl0OvqMoxq/UMgMSCLnXzkaXbxzskluEBlMQCJPms=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func serve(config *server.Config) {
 	as := &server.AuthorizationServer{}
 	as.Register(grpcServer, rsHandler)
 	ls := &server.AccessLogServer{}
-	ls.Register(grpcServer, rsHandler)
+	ls.Register(grpcServer, rsHandler, config.Global.KeepAliveMaxConnectionAge)
 
 	// grpc health
 	grpcHealth := health.NewServer()

--- a/server/config.go
+++ b/server/config.go
@@ -52,7 +52,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Global: GlobalConfig{
 			TempDir:                   "/tmp/apigee-istio",
-			KeepAliveMaxConnectionAge: 10 * time.Minute,
+			KeepAliveMaxConnectionAge: time.Minute,
 			APIAddress:                ":5000",
 			MetricsAddress:            ":5001",
 		},


### PR DESCRIPTION
It is using the config option to set the timeout for access log streams.

The default duration is changed from 10 minutes to 1 minute. This makes sense to me since terminating connection sooner does little harm when the traffic is low while it enables load balancing more efficiently when traffic is high.

-golib dependencies is changed to the latest.

close #77