### PR TITLE
enabled jwtProviderKey option

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -78,7 +78,6 @@ github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELB
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.6 h1:GgblEiDzxf5ajlAZY4aC8xp7DwkrGfauFNMGdB2bBv0=
 github.com/envoyproxy/go-control-plane v0.9.6/go.mod h1:GFqM7v0B62MraO4PWRedIbhThr/Rf7ev6aHOOPXeaDA=
-github.com/envoyproxy/go-control-plane v0.9.7 h1:EARl0OvqMoxq/UMgMSCLnXzkaXbxzskluEBlMQCJPms=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/server/config.go
+++ b/server/config.go
@@ -153,7 +153,7 @@ type AuthConfig struct {
 	APIKeyHeader        string        `yaml:"api_key_header,omitempty" json:"api_key_header,omitempty"`
 	TargetHeader        string        `yaml:"target_header,omitempty" json:"target_header,omitempty"`
 	RejectUnauthorized  bool          `yaml:"reject_unauthorized,omitempty" json:"reject_unauthorized,omitempty"`
-	JWTProviderKey      string        `yaml:"-" json:"-"`
+	JWTProviderKey      string        `yaml:"jwt_provider_key,omitempty" json:"jwt_provider_key,omitempty"`
 }
 
 // Load config

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -67,7 +67,8 @@ auth:
   api_key_header: x-api-key
   target_header: :authority
   reject_unauthorized: true
-  jwks_poll_interval: 0s`
+  jwks_poll_interval: 0s
+  jwt_provider_key: apigee`
 
 	configMapConfigKey = "config.yaml"
 )


### PR DESCRIPTION
close #9 

- yaml and json annotations for the `jwtProviderKey` field are added.
- The behavior does not change with unset (default option) `jwtProviderKey`.
- Tests are added with a more real `jwtClaims` and commented lines got removed.
