### PR TITLE
added gcloud build

### DIFF
--- a/kokoro/scripts/integration_test_hybrid.sh
+++ b/kokoro/scripts/integration_test_hybrid.sh
@@ -393,6 +393,7 @@ function cleanUp {
 echo -e "\nStarting integration test of the Apigee Envoy Adapter with Apigee Hybrid..."
 
 setEnvironmentVariables
+buildDockerImages
 provisionRemoteService
 generateSampleConfigurations istio-1.6
 applyToCluster


### PR DESCRIPTION
added back `buildDockerImages` which was accidentally removed during troubleshooting early on.