### PR TITLE
changes to config loading and validation to better support application default credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 			fmt.Printf("apigee-remote-service-envoy version %s %s [%s]\n", version, date, commit)
 
 			config := server.DefaultConfig()
-			if err := config.Load(configFile, policySecretPath, analyticsSecretPath); err != nil {
+			if err := config.Load(configFile, policySecretPath, analyticsSecretPath, true); err != nil {
 				log.Errorf("Unable to load config: %s:\n%v", configFile, err)
 				os.Exit(1)
 			}

--- a/server/config.go
+++ b/server/config.go
@@ -253,7 +253,7 @@ func (c *Config) Load(configFile, policySecretPath, analyticsSecretPath string, 
 			if err != nil {
 				if analyticsSecretPath == DefaultAnalyticsSecretPath {
 					// allows fall back to default credentials or fluentd if the path is the default one
-					log.Warnf("analytics service account credentials not found on default path, using credentials from config file")
+					log.Warnf("analytics service account credentials not found on default path, falling back to credentials from config file")
 				} else {
 					// returns error if the invalid path is explicitly specified
 					return err
@@ -297,7 +297,7 @@ func (c *Config) Validate(requireAnalyticsCredentials bool) error {
 		if c.Tenant.InternalAPI == "" && c.Analytics.FluentdEndpoint == "" && requireAnalyticsCredentials {
 			cred, err := google.FindDefaultCredentials(context.Background(), ApigeeAPIScope)
 			if err != nil {
-				errs = multierror.Append(errs, fmt.Errorf("tenant.internal_api or tenant.analytics.fluentd_endpoint is required if no service account"))
+				errs = multierror.Append(errs, fmt.Errorf("tenant.internal_api or tenant.analytics.fluentd_endpoint is required if analytics credentials not given"))
 			} else { // to avoid the non-name error
 				c.Analytics.Credentials = cred
 			}

--- a/server/config.go
+++ b/server/config.go
@@ -240,16 +240,18 @@ func (c *Config) Load(configFile, policySecretPath, analyticsSecretPath string) 
 		if analyticsSecretPath != "" {
 			svc := path.Join(analyticsSecretPath, ServiceAccount)
 			log.Debugf("using analytics service account credentials from: %s", svc)
-			c.Analytics.CredentialsJSON, err = ioutil.ReadFile(svc)
+			sa, err := ioutil.ReadFile(svc)
 			if err != nil {
 				if analyticsSecretPath == DefaultAnalyticsSecretPath {
 					// allows fall back to default credentials or fluentd if the path is the default one
-					c.Analytics.CredentialsJSON = nil
 					log.Warnf("reading analytics service account credentials from default path: %v", err)
 				} else {
 					// returns error if the invalid path is explicitly specified
 					return err
 				}
+			} else {
+				// overwrites the credentials if read from the config
+				c.Analytics.CredentialsJSON = sa
 			}
 		}
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -411,7 +411,7 @@ tenant:
 	}
 
 	wantErrs := []string{
-		"tenant.internal_api or tenant.analytics.fluentd_endpoint is required if no service account",
+		"tenant.internal_api or tenant.analytics.fluentd_endpoint is required if analytics credentials not given",
 	}
 	merr := err.(*multierror.Error)
 	if merr.Len() != len(wantErrs) {
@@ -549,7 +549,7 @@ func TestValidate(t *testing.T) {
 
 	wantErrs = []string{
 		"tenant.remote_service_api is required",
-		"tenant.internal_api or tenant.analytics.fluentd_endpoint is required if no service account",
+		"tenant.internal_api or tenant.analytics.fluentd_endpoint is required if analytics credentials not given",
 		"tenant.org_name is required",
 		"tenant.env_name is required",
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -164,7 +164,7 @@ func TestHybridSingleFile(t *testing.T) {
 	}
 
 	c := DefaultConfig()
-	if err := c.Load(tf.Name(), "xxx", DefaultAnalyticsSecretPath); err != nil {
+	if err := c.Load(tf.Name(), "xxx", DefaultAnalyticsSecretPath, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -206,7 +206,7 @@ func TestMultifileConfig(t *testing.T) {
 	}
 
 	c := DefaultConfig()
-	if err := c.Load(tf.Name(), secretDir, ""); err != nil {
+	if err := c.Load(tf.Name(), secretDir, "", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -241,7 +241,7 @@ func TestIncompletePolicySecret(t *testing.T) {
 	}
 
 	c := DefaultConfig()
-	if err := c.Load(tf.Name(), "", ""); err != nil {
+	if err := c.Load(tf.Name(), "", "", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -274,7 +274,7 @@ func TestLoadOrders(t *testing.T) {
 	}
 
 	c := DefaultConfig()
-	if err := c.Load(tf.Name(), "", ""); err != nil {
+	if err := c.Load(tf.Name(), "", "", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -305,7 +305,7 @@ func TestLoadOrders(t *testing.T) {
 	}
 
 	c = DefaultConfig()
-	if err := c.Load(tf.Name(), "", ""); err != nil {
+	if err := c.Load(tf.Name(), "", "", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -337,7 +337,7 @@ func TestLoadLegacyConfig(t *testing.T) {
 	}
 
 	c := &Config{}
-	if err := c.Load(tf.Name(), "xxx", ""); err != nil {
+	if err := c.Load(tf.Name(), "xxx", "", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -385,7 +385,7 @@ tenant:
 
 	// valid path to analytics credentials
 	c := DefaultConfig()
-	if err := c.Load(tf.Name(), "", credDir); err != nil {
+	if err := c.Load(tf.Name(), "", credDir, true); err != nil {
 		t.Error(err)
 	}
 
@@ -396,7 +396,7 @@ tenant:
 	// set valid GOOGLE_APPLICATION_CREDENTIALS
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credFile)
 	c = DefaultConfig()
-	if err := c.Load(tf.Name(), "", ""); err != nil {
+	if err := c.Load(tf.Name(), "", "", true); err != nil {
 		t.Error(err)
 	}
 
@@ -405,7 +405,7 @@ tenant:
 	// any interference from the test environment
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "not valid")
 	c = DefaultConfig()
-	err = c.Load(tf.Name(), "", "")
+	err = c.Load(tf.Name(), "", "", true)
 	if err == nil {
 		t.Fatal("want error got none")
 	}
@@ -453,7 +453,7 @@ func TestAnalyticsRollback(t *testing.T) {
 
 	// analytics to be rolled back to that from config file
 	c = DefaultConfig()
-	err = c.Load(tf.Name(), "", DefaultAnalyticsSecretPath)
+	err = c.Load(tf.Name(), "", DefaultAnalyticsSecretPath, true)
 	if err != nil {
 		t.Errorf("want no error got %v", err)
 	}
@@ -463,7 +463,7 @@ func TestAnalyticsRollback(t *testing.T) {
 
 	// invalid path to analytics credentials
 	c = DefaultConfig()
-	err = c.Load(tf.Name(), "", "no such path")
+	err = c.Load(tf.Name(), "", "no such path", true)
 	if err == nil {
 		t.Error("want error got none")
 	} else {
@@ -487,7 +487,7 @@ func TestInvalidConfig(t *testing.T) {
 	}
 
 	c := &Config{}
-	if err := c.Load(tf.Name(), "", ""); err == nil {
+	if err := c.Load(tf.Name(), "", "", true); err == nil {
 		t.Error("should have gotten error")
 	}
 
@@ -511,7 +511,7 @@ func TestInvalidConfig(t *testing.T) {
 	}
 
 	c = &Config{}
-	if err := c.Load(tf.Name(), "", ""); err == nil {
+	if err := c.Load(tf.Name(), "", "", true); err == nil {
 		t.Error("should have gotten error")
 	}
 }
@@ -539,24 +539,45 @@ func TestValidate(t *testing.T) {
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "invalid path")
 
 	c := &Config{}
-	err := c.Validate()
+	var wantErrs []string
+	var merr *multierror.Error
+
+	err := c.Validate(true)
 	if err == nil {
 		t.Fatal("should have gotten errors")
 	}
 
-	wantErrs := []string{
+	wantErrs = []string{
 		"tenant.remote_service_api is required",
 		"tenant.internal_api or tenant.analytics.fluentd_endpoint is required if no service account",
 		"tenant.org_name is required",
 		"tenant.env_name is required",
 	}
-	merr := err.(*multierror.Error)
+	merr = err.(*multierror.Error)
 	if merr.Len() != len(wantErrs) {
 		t.Fatalf("got %d errors, want: %d, errors: %s", merr.Len(), len(wantErrs), merr)
 	}
 
-	errs := merr.Errors
-	for i, e := range errs {
+	for i, e := range merr.Errors {
+		equal(t, e.Error(), wantErrs[i])
+	}
+
+	err = c.Validate(false)
+	if err == nil {
+		t.Fatal("should have gotten errors")
+	}
+
+	wantErrs = []string{
+		"tenant.remote_service_api is required",
+		"tenant.org_name is required",
+		"tenant.env_name is required",
+	}
+	merr = err.(*multierror.Error)
+	if merr.Len() != len(wantErrs) {
+		t.Fatalf("got %d errors, want: %d, errors: %s", merr.Len(), len(wantErrs), merr)
+	}
+
+	for i, e := range merr.Errors {
 		equal(t, e.Error(), wantErrs[i])
 	}
 }
@@ -589,7 +610,7 @@ func TestValidateTLS(t *testing.T) {
 		config.Analytics.TLS.CertFile = o[3]
 		config.Analytics.TLS.KeyFile = o[4]
 
-		err := config.Validate()
+		err := config.Validate(true)
 		if err == nil {
 			t.Fatal("should have gotten errors")
 		}

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -114,7 +114,7 @@ func TestNewHandler(t *testing.T) {
 		t.Error(err)
 	}
 	if h.internalAPI.Host != "apigee.googleapis.com" {
-		t.Errorf("intervalAPI error: want %s got %s", "apigee.googleapis.com", h.internalAPI.Host)
+		t.Errorf("internalAPI error: want %s got %s", "apigee.googleapis.com", h.internalAPI.Host)
 	}
 
 	tf, err := ioutil.TempFile("", "")


### PR DESCRIPTION
In this version, I introduced the `Analytics.Credentials *google.Credentials` in addition to `Analytics.CredentialsJSON []byte`. And `Credentials` will be loaded from config, given path or application default credentials during the config loading and validation process. As a result, the `NewHandler()` method can unambiguously decide how to construct an analytics http client .

What is left to be addressed is that `Load()` method is also called by -cli during provisioning or other commands. When users intend to use ADC to authorize the adapter, they may still run CLI in a different environment lacking such credentials. We may need to introduce another argument to the `Load()` method to indicate whether it is invoked by CLI and allow validation of a config lacking explicit credentials.

This will close #96