### PR TITLE
default JWTProviderKey to empty string

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -78,7 +78,6 @@ func DefaultConfig() *Config {
 			APIKeyHeader:        "x-api-key",
 			TargetHeader:        ":authority",
 			RejectUnauthorized:  false,
-			JWTProviderKey:      "apigee",
 		},
 	}
 }


### PR DESCRIPTION
to fix https://github.com/apigee/apigee-remote-service-cli/issues/110