### PR TITLE
exporting LoadPrivateKey for -cli to use

### DIFF
--- a/server/authmanager.go
+++ b/server/authmanager.go
@@ -124,7 +124,7 @@ func (a *JWTAuthManager) getToken() *jwt.Token {
 	return a.authToken
 }
 
-func loadPrivateKey(privateKeyBytes []byte, rsaPrivateKeyPassword string) (*rsa.PrivateKey, error) {
+func LoadPrivateKey(privateKeyBytes []byte, rsaPrivateKeyPassword string) (*rsa.PrivateKey, error) {
 
 	var err error
 	privPem, _ := pem.Decode(privateKeyBytes)

--- a/server/config.go
+++ b/server/config.go
@@ -235,7 +235,7 @@ func (c *Config) Load(configFile, policySecretPath, analyticsSecretPath string, 
 		jwks := &jwk.Set{}
 		if err = json.Unmarshal(jwksBytes, jwks); err == nil {
 			c.Tenant.JWKS = jwks
-			if c.Tenant.PrivateKey, err = loadPrivateKey(key, ""); err != nil {
+			if c.Tenant.PrivateKey, err = LoadPrivateKey(key, ""); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This is regarding: https://github.com/apigee/apigee-remote-service-cli/issues/121

It's to reuse this `LoadPrivateKey` method to load the key from the retrieved propertyset during provision.