### PR TITLE
added operationgroup tests; eliminated spurious errors from quotas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 // replace github.com/apigee/apigee-remote-service-golib => ../apigee-remote-service-golib
 
 require (
-	github.com/apigee/apigee-remote-service-golib v1.4.0
+	github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210106205343-952d410b2165
 	github.com/envoyproxy/go-control-plane v0.9.7
 	github.com/gogo/googleapis v1.4.0
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apigee/apigee-remote-service-golib v1.4.0 h1:alZuIaYo/4Y4NuEh0AtK5PD69veAH4zFBAi/+QLZTJg=
-github.com/apigee/apigee-remote-service-golib v1.4.0/go.mod h1:v8JlgWxYdj2CtCbV3qMWdjyVxtHjnbDnFZl6v1XCWEY=
+github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210106205343-952d410b2165 h1:B7ysA8hICT4nVqYXIhDluuzk50lagRpLdgXy9H+JtVs=
+github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210106205343-952d410b2165/go.mod h1:v8JlgWxYdj2CtCbV3qMWdjyVxtHjnbDnFZl6v1XCWEY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -21,3 +21,46 @@
 9 - error provisioning with CG SaaS
 
 10 - error during load tests
+
+### Run the test locally
+
+*NOTE*: As of now, the test scripts do not create a sandbox environment. Instead they rely on existing Apigee platforms and credentials. Therefore, running the scripts locally still require permission to access those resources and they are not meant for general use. However, some functions defined in `scripts/lib.sh` might appear to be useful.
+
+Given proper access to the credentials, the script below can be used to simulate the Kokoro build locally.
+
+```
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+export REPOS_DIR=${path to your apigee-remote-service-envoy and apigee-remote-service-cli repos}
+export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
+
+export CGSAAS_ISTIO_TEMPLATE=istio-1.7
+export CGSAAS_ENVOY_TEMPLATE=envoy-1.16
+export CGSAAS_ENVOY_TAG=v1.16.0
+export HYBRID_ISTIO_TEMPLATE=istio-1.6
+export HYBRID_ENVOY_TEMPLATE=envoy-1.16
+export HYBRID_ENVOY_TAG=v1.16.0
+export OPDK_ENVOY_TEMPLATE=envoy-1.15
+export OPDK_ENVOY_TAG=v1.15.0
+export CGO_ENABLED=0 # 1
+export RUN_CONTAINER=gcr.io/distroless/base # ubuntu:xenial
+export BUILD_CONTAINER=golang:1.15 # goboring/golang:1.15.6b5
+
+# uncomment one of the following command to test a specific Apigee platform
+# export ADAPTER_IMAGE_TAG=hybrid-test
+# export ADAPTER_IMAGE_TAG=opdk-test
+# export ADAPTER_IMAGE_TAG=cgsaas-test
+
+. ${BUILD_DIR}/scripts/lib.sh
+
+buildRemoteServiceCLI
+buildAdapterDocker
+
+# uncomment one of the following command to test a specific Apigee platform
+# ${BUILD_DIR}/scripts/integration_test_hybrid.sh
+# ${BUILD_DIR}/scripts/integration_test_opdk.sh
+# ${BUILD_DIR}/scripts/integration_test_cgsaas.sh
+```

--- a/kokoro/gcp_ubuntu/cgsaas_build.sh
+++ b/kokoro/gcp_ubuntu/cgsaas_build.sh
@@ -17,7 +17,8 @@
 # Fail on any error.
 set -e
 
-BUILD_DIR=${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro
+export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
+export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
 ${BUILD_DIR}/scripts/init.sh
 

--- a/kokoro/gcp_ubuntu/hybrid.cfg
+++ b/kokoro/gcp_ubuntu/hybrid.cfg
@@ -15,6 +15,16 @@ env_vars {
 }
 
 env_vars {
+  key: "HYBRID_ENVOY_TEMPLATE"
+  value: "envoy-1.16"
+}
+
+env_vars {
+  key: "HYBRID_ENVOY_TAG"
+  value: "v1.16.0"
+}
+
+env_vars {
   key: "CGO_ENABLED"
   value: "0"
 }

--- a/kokoro/gcp_ubuntu/hybrid_build.sh
+++ b/kokoro/gcp_ubuntu/hybrid_build.sh
@@ -17,7 +17,8 @@
 # Fail on any error.
 set -e
 
-BUILD_DIR=${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro
+export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
+export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
 ${BUILD_DIR}/scripts/init.sh
 

--- a/kokoro/gcp_ubuntu/loadtest_build.sh
+++ b/kokoro/gcp_ubuntu/loadtest_build.sh
@@ -17,7 +17,8 @@
 # Fail on any error.
 set -e
 
-BUILD_DIR=${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro
+export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
+export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
 ${BUILD_DIR}/scripts/init.sh
 

--- a/kokoro/gcp_ubuntu/opdk_build.sh
+++ b/kokoro/gcp_ubuntu/opdk_build.sh
@@ -17,7 +17,8 @@
 # Fail on any error.
 set -e
 
-BUILD_DIR=${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro
+export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
+export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
 ${BUILD_DIR}/scripts/init.sh
 

--- a/kokoro/payloads/hybrid_app.json
+++ b/kokoro/payloads/hybrid_app.json
@@ -1,0 +1,7 @@
+{
+  "name" : "httpbin-app",
+  "apiProducts": [
+    "httpbin-product",
+    "opgrp-product"
+  ]
+}

--- a/kokoro/payloads/hybrid_product.json
+++ b/kokoro/payloads/hybrid_product.json
@@ -1,0 +1,27 @@
+{
+  "name": "httpbin-product",
+  "displayName": "httpbin product",
+  "approvalType": "auto",
+  "attributes": [
+    {
+      "name": "access",
+      "value": "private"
+    },
+    {
+      "name": "apigee-remote-service-targets",
+      "value": "httpbin.org,httpbin.default.svc.cluster.local"
+    }
+  ],
+  "description": "httpbin product for test purpose",
+  "apiResources": [
+    "/httpbin/headers",
+    "/headers"
+  ],
+  "environments": [
+    "test",
+    "test2"
+  ],
+  "quota": "5",
+  "quotaInterval": "1",
+  "quotaTimeUnit": "minute"
+}

--- a/kokoro/payloads/opgrp_product.json
+++ b/kokoro/payloads/opgrp_product.json
@@ -1,0 +1,52 @@
+{
+  "name": "opgrp-product",
+  "displayName": "opgrp product",
+  "approvalType": "auto",
+  "attributes": [
+    {
+      "name": "access",
+      "value": "private"
+    }
+  ],
+  "description": "httpbin product for test purpose",
+  "operationGroup": {
+    "operationConfigs": [
+      {
+        "apiSource": "httpbin.default.svc.cluster.local",
+        "operations": [
+          {
+            "resource": "/get",
+            "methods": [
+              "GET"
+            ]
+          }
+        ],
+        "quota": {
+          "limit": "5",
+          "interval": "1",
+          "timeUnit": "minute"
+        }
+      },
+      {
+        "apiSource": "httpbin.default.svc.cluster.local",
+        "operations": [
+          {
+            "resource": "/post",
+            "methods": [
+              "POST"
+            ]
+          }
+        ],
+        "quota": {
+          "limit": "5",
+          "interval": "1",
+          "timeUnit": "minute"
+        }
+      }
+    ],
+    "operationConfigType": "remoteservice"
+  },
+  "environments": [
+    "test"
+  ]
+}

--- a/kokoro/scripts/init.sh
+++ b/kokoro/scripts/init.sh
@@ -17,48 +17,8 @@
 # Fail on any error.
 set -e
 
-################################################################################
-# Build CLI from source code
-################################################################################
-function installPrerequisites {
-  echo -e "\nInstalling jq..."
-  sudo apt install jq -y
-
-  echo -e "\nUpdating gcloud SDK..."
-  gcloud components update --quiet
-
-  echo -e "\nInstalling go 1.15..."
-  if [[ -d "/usr/local/go" ]] ; then 
-    sudo rm -r /usr/local/go
-  fi
-  curl -LO https://golang.org/dl/go1.15.6.linux-amd64.tar.gz
-  sudo tar -C /usr/local -xzf go1.15.6.linux-amd64.tar.gz
-  export PATH=$PATH:/usr/local/go/bin
-  sudo chmod 777 /usr/local/go
-}
-
-################################################################################
-# Build CLI from source code
-################################################################################
-function buildRemoteServiceCLI {
-  echo -e "\nBuilding apigee-remote-service-cli..."
-  cd ${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-cli
-  go mod download
-  CGO_ENABLED=0 go build -a -o apigee-remote-service-cli .
-}
-
-################################################################################
-# Build Adapter Docker Image from source code
-################################################################################
-function buildAdapterDocker {
-  echo -e "\nBuilding local Docker image of apigee-remote-service-envoy..."
-  cd ${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy
-  docker build -t apigee-envoy-adapter:${ADAPTER_IMAGE_TAG} \
-    --build-arg CGO_ENABLED=${GCO_ENABLED} \
-    --build-arg RUN_CONTAINER=${RUN_CONTAINER} \
-    --build-arg BUILD_CONTAINER=${BUILD_CONTAINER} \
-    .
-}
+# load necessary function definitions
+. ${BUILD_DIR}/scripts/lib.sh
 
 installPrerequisites
 buildRemoteServiceCLI

--- a/kokoro/scripts/integration_test_cgsaas.sh
+++ b/kokoro/scripts/integration_test_cgsaas.sh
@@ -266,26 +266,6 @@ function applyToCluster {
 }
 
 ################################################################################
-# Call Local Target With APIKey
-################################################################################
-function callTargetWithAPIKey {
-  STATUS_CODE=$(docker run --network=host curlimages/curl:7.72.0 --silent -o /dev/stderr -w "%{http_code}" \
-    localhost:8080/headers -Hhost:httpbin.org \
-    -Hx-api-key:$1)
-
-  if [[ ! -z $2 ]] ; then
-    if [[ $STATUS_CODE -ne $2 ]] ; then
-      echo -e "\nError calling local target with API key: expected status $2; got $STATUS_CODE"
-      exit 1
-    else 
-      echo -e "\nCalling local target with API key got $STATUS_CODE as expected"
-    fi
-  else
-    echo -e "\nCalling local target with API key got $STATUS_CODE"
-  fi
-}
-
-################################################################################
 # Clean up Apigee resources
 ################################################################################
 function cleanUpApigee {
@@ -371,7 +351,7 @@ function cleanUpApigee {
 echo -e "\nStarting integration test of the Apigee Envoy Adapter with Apigee SaaS..."
 
 # load necessary function definitions
-. ${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro/scripts/lib.sh
+. ${BUILD_DIR}/scripts/lib.sh
 
 setEnvironmentVariables cgsaas-env
 

--- a/kokoro/scripts/integration_test_opdk.sh
+++ b/kokoro/scripts/integration_test_opdk.sh
@@ -342,7 +342,7 @@ function cleanUpApigee {
 echo -e "\nStarting integration test of the Apigee Envoy Adapter with Apigee OPDK..."
 
 # load necessary function definitions
-. ${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro/scripts/lib.sh
+. ${BUILD_DIR}/scripts/lib.sh
 
 setEnvironmentVariables opdk-env
 

--- a/kokoro/scripts/lib.sh
+++ b/kokoro/scripts/lib.sh
@@ -536,8 +536,8 @@ function runAdditionalIstioTests {
       fi
       sleep 1
     done
-    # echo -e "\nTesting quota for /post which should be unaffected..."
-    # callIstioTargetWithAPIKey $APIKEY 200 httpbin.default.svc.cluster.local /post POST
+    echo -e "\nTesting quota for /post which should be unaffected..."
+    callIstioTargetWithAPIKey $APIKEY 200 httpbin.default.svc.cluster.local /post POST
   } || { # exit on failure
     exit 6
   }

--- a/kokoro/scripts/lib.sh
+++ b/kokoro/scripts/lib.sh
@@ -18,14 +18,59 @@
 set -e
 
 ################################################################################
+# Build CLI from source code
+################################################################################
+function installPrerequisites {
+  echo -e "\nInstalling jq..."
+  sudo apt install jq -y
+
+  echo -e "\nUpdating gcloud SDK..."
+  gcloud components update --quiet
+
+  echo -e "\nInstalling go 1.15..."
+  if [[ -d "/usr/local/go" ]] ; then 
+    sudo rm -r /usr/local/go
+  fi
+  curl -LO https://golang.org/dl/go1.15.6.linux-amd64.tar.gz
+  sudo tar -C /usr/local -xzf go1.15.6.linux-amd64.tar.gz
+  export PATH=$PATH:/usr/local/go/bin
+  sudo chmod 777 /usr/local/go
+}
+
+################################################################################
+# Build CLI from source code
+################################################################################
+function buildRemoteServiceCLI {
+  echo -e "\nBuilding apigee-remote-service-cli..."
+  cd ${REPOS_DIR}/apigee-remote-service-cli
+  go mod download
+  CGO_ENABLED=0 go build -a -o apigee-remote-service-cli .
+  export CLI=${REPOS_DIR}/apigee-remote-service-cli/apigee-remote-service-cli
+  cd -
+}
+
+################################################################################
+# Build Adapter Docker Image from source code
+################################################################################
+function buildAdapterDocker {
+  echo -e "\nBuilding local Docker image of apigee-remote-service-envoy..."
+  cd ${REPOS_DIR}/apigee-remote-service-envoy
+  docker build -t apigee-envoy-adapter:${ADAPTER_IMAGE_TAG} \
+    --build-arg CGO_ENABLED=${GCO_ENABLED} \
+    --build-arg RUN_CONTAINER=${RUN_CONTAINER} \
+    --build-arg BUILD_CONTAINER=${BUILD_CONTAINER} \
+    .
+  cd -
+}
+
+################################################################################
 # Fetching environment variables from secrets in the GCP project
 ################################################################################
 function setEnvironmentVariables {
   echo -e "\nSetting up environment variables from the GCP secret ${1}..."
   gcloud secrets versions access 1 --secret="${1}" > ${1}
   source ./${1}
-  CLI=${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-cli/apigee-remote-service-cli
-  REPO=${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy
+  REPO=${REPOS_DIR}/apigee-remote-service-envoy
 
   echo -e "\nGetting Kubernetes cluster credentials and configuring kubectl..."
   gcloud container clusters get-credentials $CLUSTER --zone $ZONE --project $PROJECT
@@ -79,8 +124,27 @@ function generateEnvoySampleConfigurations {
 # Call Local Target With APIKey
 ################################################################################
 function callTargetWithAPIKey {
-  STATUS_CODE=$(docker run --network=host curlimages/curl:7.72.0 --silent -o /dev/stderr -w "%{http_code}" \
-    localhost:8080/headers -Hhost:httpbin.org \
+  if [[ -z $3 ]] ; then
+    HOST=httpbin.org
+  else
+    HOST=$3
+  fi
+
+  if [[ -z $4 ]] ; then
+    RESOURCE_PATH=/headers
+  else
+    RESOURCE_PATH=$4
+  fi
+
+  if [[ -z $5 ]] ; then
+    METHOD=GET
+  else
+    METHOD=$5
+  fi
+
+  STATUS_CODE=$(docker run --network=host curlimages/curl:7.72.0 -X $METHOD \
+    --silent -o /dev/stderr -w "%{http_code}" \
+    localhost:8080$RESOURCE_PATH -Hhost:$HOST \
     -Hx-api-key:$1)
 
   if [[ ! -z $2 ]] ; then
@@ -99,8 +163,27 @@ function callTargetWithAPIKey {
 # call Local Target With JWT
 ################################################################################
 function callTargetWithJWT {
-  STATUS_CODE=$(docker run --network=host curlimages/curl:7.72.0 --silent -o /dev/stderr -w "%{http_code}" \
-    localhost:8080/headers -Hhost:httpbin.org \
+  if [[ -z $3 ]] ; then
+    HOST=httpbin.org
+  else
+    HOST=$3
+  fi
+
+  if [[ -z $4 ]] ; then
+    RESOURCE_PATH=/headers
+  else
+    RESOURCE_PATH=$4
+  fi
+
+  if [[ -z $5 ]] ; then
+    METHOD=GET
+  else
+    METHOD=$5
+  fi
+
+  STATUS_CODE=$(docker run --network=host curlimages/curl:7.72.0 -X $METHOD \
+    --silent -o /dev/stderr -w "%{http_code}" \
+    localhost:8080$RESOURCE_PATH -Hhost:$HOST \
     -H "Authorization: Bearer $1")
 
   if [[ ! -z $2 ]] ; then
@@ -119,9 +202,27 @@ function callTargetWithJWT {
 # Call Target on Istio With APIKey
 ################################################################################
 function callIstioTargetWithAPIKey {
+  if [[ -z $3 ]] ; then
+    HOST=httpbin.default.svc.cluster.local
+  else
+    HOST=$3
+  fi
+
+  if [[ -z $4 ]] ; then
+    RESOURCE_PATH=/headers
+  else
+    RESOURCE_PATH=$4
+  fi
+
+  if [[ -z $5 ]] ; then
+    METHOD=GET
+  else
+    METHOD=$5
+  fi
+
   STATUS_CODE=$(kubectl exec curl -c curl -- \
-    curl --silent -o /dev/stderr -w "%{http_code}" \
-    httpbin.default.svc.cluster.local/headers \
+    curl -X $METHOD --silent -o /dev/stderr -w "%{http_code}" \
+    ${HOST}${RESOURCE_PATH} \
     -Hx-api-key:$1)
 
   if [[ ! -z $2 ]] ; then
@@ -140,9 +241,27 @@ function callIstioTargetWithAPIKey {
 # call Target on Istio With JWT
 ################################################################################
 function callIstioTargetWithJWT {
+  if [[ -z $3 ]] ; then
+    HOST=httpbin.default.svc.cluster.local
+  else
+    HOST=$3
+  fi
+
+  if [[ -z $4 ]] ; then
+    RESOURCE_PATH=/headers
+  else
+    RESOURCE_PATH=$4
+  fi
+
+  if [[ -z $5 ]] ; then
+    METHOD=GET
+  else
+    METHOD=$5
+  fi
+
   STATUS_CODE=$(kubectl exec curl -c curl -- \
-    curl --silent -o /dev/stderr -w "%{http_code}" \
-    httpbin.default.svc.cluster.local/headers \
+    curl -X $METHOD --silent -o /dev/stderr -w "%{http_code}" \
+    ${HOST}${RESOURCE_PATH} \
     -H "Authorization: Bearer $1")
 
   if [[ ! -z $2 ]] ; then
@@ -235,14 +354,17 @@ function runEnvoyTests {
       fi
       sleep 1
     done
-    callTargetWithAPIKey $APIKEY 403
+    if [[ $STATUS_CODE -ne 403 ]] ; then
+      echo -e "\nQuota was not exhausted"
+      exit 2
+    fi
     
     sleep 65
 
     echo -e "\nQuota should have restored"
     callTargetWithAPIKey $APIKEY 200
 
-    undeployRemoteServiceProxies
+    undeployRemoteServiceProxies $ENV $RUNTIME
 
     for i in {1..20}
     do
@@ -253,14 +375,17 @@ function runEnvoyTests {
       fi
       sleep 1
     done
-    callTargetWithAPIKey $APIKEY 403
+    if [[ $STATUS_CODE -ne 403 ]] ; then
+      echo -e "\nQuota was not exhausted"
+      exit 2
+    fi
     
     sleep 65
     
     echo -e "\nLocal quota should have restored"
     callTargetWithAPIKey $APIKEY 200
 
-    deployRemoteServiceProxies $REV
+    deployRemoteServiceProxies $REV $ENV $RUNTIME
   } || { # exit on failure
     exit 7
   }
@@ -350,14 +475,17 @@ EOF
       fi
       sleep 1
     done
-    callIstioTargetWithAPIKey $APIKEY 403
+    if [[ $STATUS_CODE -ne 403 ]] ; then
+      echo -e "\nQuota was not exhausted"
+      exit 4
+    fi
     
     sleep 65
 
     echo -e "\nQuota should have restored"
     callIstioTargetWithAPIKey $APIKEY 200
 
-    undeployRemoteServiceProxies
+    undeployRemoteServiceProxies $ENV $RUNTIME
 
     for i in {1..20}
     do
@@ -368,14 +496,48 @@ EOF
       fi
       sleep 1
     done
-    callIstioTargetWithAPIKey $APIKEY 403
+    if [[ $STATUS_CODE -ne 403 ]] ; then
+      echo -e "\nQuota was not exhausted"
+      exit 4
+    fi
     
     sleep 65
     
     echo -e "\nLocal quota should have restored"
     callIstioTargetWithAPIKey $APIKEY 200
 
-    deployRemoteServiceProxies $REV
+    deployRemoteServiceProxies $REV $ENV $RUNTIME
+  } || { # exit on failure
+    exit 6
+  }
+}
+
+################################################################################
+# Run additional tests regarding API Product Operation Group on Istio
+################################################################################
+function runAdditionalIstioTests {
+  echo -e "\nStarting to run tests on Istio..."
+  {
+    echo -e "\nCalling /get with GET"
+    callIstioTargetWithAPIKey $APIKEY 200 httpbin.default.svc.cluster.local /get GET
+    echo -e "\nCalling /post with POST"
+    callIstioTargetWithAPIKey $APIKEY 200 httpbin.default.svc.cluster.local /post POST
+    echo -e "\nCalling /get with POST"
+    callIstioTargetWithAPIKey $APIKEY 403 httpbin.default.svc.cluster.local /get POST
+    echo -e "\nCalling /post with GET"
+    callIstioTargetWithAPIKey $APIKEY 403 httpbin.default.svc.cluster.local /post GET
+    
+    for i in {1..20}
+    do
+      callIstioTargetWithAPIKey $APIKEY "" httpbin.default.svc.cluster.local /get GET
+      if [[ $STATUS_CODE -eq 403 ]] ; then
+        echo -e "\nQuota for /get depleted"
+        break
+      fi
+      sleep 1
+    done
+    # echo -e "\nTesting quota for /post which should be unaffected..."
+    # callIstioTargetWithAPIKey $APIKEY 200 httpbin.default.svc.cluster.local /post POST
   } || { # exit on failure
     exit 6
   }

--- a/kokoro/scripts/load_test.sh
+++ b/kokoro/scripts/load_test.sh
@@ -18,7 +18,7 @@
 set -e
 
 # load necessary function definitions
-. ${KOKORO_ARTIFACTS_DIR}/github/apigee-remote-service-envoy/kokoro/scripts/lib.sh
+. ${BUILD_DIR}/scripts/lib.sh
 
 setEnvironmentVariables loadtest-env
 


### PR DESCRIPTION
related to #93 

* Quota tests now check the last status code from the loop and verify the quota depletion. This eliminates spurious errors from the case where the quota bucket incidentally recovers right after its depletion and returns unexpected status code.
* Added tests on API product with OperationGroup. The quota identifier issue remains to be resolved: https://github.com/apigee/apigee-remote-service-golib/issues/34
* Test scripts and Kokoro build scripts are further separated so that the test scripts can be better run locally without additional tweaks provided necessary environment variables.