### PR TITLE
fixed the env var exports to the sub-shell scripts

### DIFF
--- a/kokoro/gcp_ubuntu/cgsaas_build.sh
+++ b/kokoro/gcp_ubuntu/cgsaas_build.sh
@@ -20,6 +20,6 @@ set -e
 export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
 export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
-${BUILD_DIR}/scripts/init.sh
+source ${BUILD_DIR}/scripts/init.sh
 
 ${BUILD_DIR}/scripts/integration_test_cgsaas.sh

--- a/kokoro/gcp_ubuntu/hybrid_build.sh
+++ b/kokoro/gcp_ubuntu/hybrid_build.sh
@@ -20,6 +20,6 @@ set -e
 export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
 export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
-${BUILD_DIR}/scripts/init.sh
+source ${BUILD_DIR}/scripts/init.sh
 
 ${BUILD_DIR}/scripts/integration_test_hybrid.sh

--- a/kokoro/gcp_ubuntu/opdk_build.sh
+++ b/kokoro/gcp_ubuntu/opdk_build.sh
@@ -20,6 +20,6 @@ set -e
 export REPOS_DIR=${KOKORO_ARTIFACTS_DIR}/github
 export BUILD_DIR=${REPOS_DIR}/apigee-remote-service-envoy/kokoro
 
-${BUILD_DIR}/scripts/init.sh
+source ${BUILD_DIR}/scripts/init.sh
 
 ${BUILD_DIR}/scripts/integration_test_opdk.sh


### PR DESCRIPTION
This is to fix the kokoro build scripts. The CLI was build and exported in `init.sh`, so its path needs to be retrievable from the subsequent script.