### PR TITLE
removed prerequisite installation

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -56,10 +56,7 @@ export BUILD_CONTAINER=golang:1.15 # goboring/golang:1.15.6b5
 # export ADAPTER_IMAGE_TAG=opdk-test
 # export ADAPTER_IMAGE_TAG=cgsaas-test
 
-. ${BUILD_DIR}/scripts/lib.sh
-
-buildRemoteServiceCLI
-buildAdapterDocker
+. ${BUILD_DIR}/scripts/init.sh
 
 # uncomment one of the following command to test a specific Apigee platform
 # ${BUILD_DIR}/scripts/hybrid_test.sh

--- a/integration-test/scripts/init.sh
+++ b/integration-test/scripts/init.sh
@@ -20,6 +20,5 @@ set -e
 # load necessary function definitions
 . ${BUILD_DIR}/scripts/lib.sh
 
-installPrerequisites
 buildRemoteServiceCLI
 buildAdapterDocker

--- a/integration-test/scripts/lib.sh
+++ b/integration-test/scripts/lib.sh
@@ -20,26 +20,6 @@ set -e
 ################################################################################
 # Build CLI from source code
 ################################################################################
-function installPrerequisites {
-  echo -e "\nInstalling jq..."
-  sudo apt install jq -y
-
-  echo -e "\nUpdating gcloud SDK..."
-  gcloud components update --quiet
-
-  echo -e "\nInstalling go 1.15..."
-  if [[ -d "/usr/local/go" ]] ; then 
-    sudo rm -r /usr/local/go
-  fi
-  curl -LO https://golang.org/dl/go1.15.6.linux-amd64.tar.gz
-  sudo tar -C /usr/local -xzf go1.15.6.linux-amd64.tar.gz
-  export PATH=$PATH:/usr/local/go/bin
-  sudo chmod 777 /usr/local/go
-}
-
-################################################################################
-# Build CLI from source code
-################################################################################
 function buildRemoteServiceCLI {
   echo -e "\nBuilding apigee-remote-service-cli..."
   cd ${REPOS_DIR}/apigee-remote-service-cli


### PR DESCRIPTION
This is still related to issue #134 

It will make the script cleaner by moving the prerequisite installation internal as we don't need to install them every time locally.