### PR TITLE
update docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -153,6 +153,6 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
             BUILD_CONTAINER=goboring/golang:1.15.6b5
-            RUN_CONTAINER=gcr.io/distroless/static
+            RUN_CONTAINER=gcr.io/distroless/base
             CGO_ENABLED=1
             LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,7 +61,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.prep.outputs.tags }}
-          build-args: LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}
+          build-args: |
+            RUN_CONTAINER=gcr.io/distroless/static
+            LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}
 
   ubuntu:
     name: Build Ubuntu Docker image
@@ -150,7 +152,7 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
-            RUN_CONTAINER=ubuntu:xenial
             BUILD_CONTAINER=goboring/golang:1.15.6b5
+            RUN_CONTAINER=gcr.io/distroless/static
             CGO_ENABLED=1
             LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,9 +61,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.prep.outputs.tags }}
-          build-args: |
-            RUN_CONTAINER=gcr.io/distroless/static
-            LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}
+          build-args: LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}
 
   ubuntu:
     name: Build Ubuntu Docker image
@@ -152,7 +150,7 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
-            BUILD_CONTAINER=goboring/golang:1.15.6b5
+            BUILD_CONTAINER=goboring/golang:1.15.7b5
             RUN_CONTAINER=gcr.io/distroless/base
             CGO_ENABLED=1
             LDFLAGS=-s -w -X main.version=${{ steps.prep.outputs.version }} -X main.commit=${{ github.SHA }} -X main.date=${{ steps.prep.outputs.created }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@
 
 # Use the following combination to build an image linked with Boring Crypto:
 # --build-arg CGO_ENABLED=1
-# --build-arg BUILD_CONTAINER=goboring/golang:1.15.6b5
-# --build-arg RUN_CONTAINER=ubuntu:xenial
+# --build-arg BUILD_CONTAINER=goboring/golang:1.15.7b5
+# --build-arg RUN_CONTAINER=gcr.io/distroless/base
 
 ARG BUILD_CONTAINER=golang:1.15
-ARG RUN_CONTAINER=gcr.io/distroless/base
+ARG RUN_CONTAINER=gcr.io/distroless/static
 
 #--- Build binary in Go container ---#
 FROM ${BUILD_CONTAINER} as builder


### PR DESCRIPTION
updated goboring version
distroless/static for default (13m -> 6m)
distroless/base for goboring (50m -> 14m, more secure)
