### PR TITLE
multitenant env support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 // replace github.com/apigee/apigee-remote-service-golib => ../apigee-remote-service-golib
 
 require (
-	github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210106205343-952d410b2165
+	github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210127172319-6ac528b724ab
 	github.com/envoyproxy/go-control-plane v0.9.7
 	github.com/gogo/googleapis v1.4.0
 	github.com/golang/protobuf v1.4.3
@@ -15,7 +15,6 @@ require (
 	github.com/lestrrat-go/jwx v1.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
-	github.com/prometheus/common v0.15.0
 	github.com/spf13/cobra v1.1.1
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210106205343-952d410b2165 h1:B7ysA8hICT4nVqYXIhDluuzk50lagRpLdgXy9H+JtVs=
-github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210106205343-952d410b2165/go.mod h1:v8JlgWxYdj2CtCbV3qMWdjyVxtHjnbDnFZl6v1XCWEY=
+github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210127172319-6ac528b724ab h1:jsxEqPIXzGX8TzpWErS4Jvec7Bmy82xKW4R7kV3HKPw=
+github.com/apigee/apigee-remote-service-golib v1.4.1-0.20210127172319-6ac528b724ab/go.mod h1:v8JlgWxYdj2CtCbV3qMWdjyVxtHjnbDnFZl6v1XCWEY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -373,9 +373,8 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
+github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
-github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=

--- a/server/accesslog.go
+++ b/server/accesslog.go
@@ -66,7 +66,7 @@ func (a *AccessLogServer) StreamAccessLogs(srv als.AccessLogService_StreamAccess
 			if err := a.handleHTTPLogs(msg); err != nil {
 				status = "error"
 			}
-			prometheusAnalyticsRequests.WithLabelValues(a.handler.orgName, a.handler.envName, status).Inc()
+			prometheusAnalyticsRequests.WithLabelValues(a.handler.orgName, status).Inc()
 			if err != nil {
 				return err
 			}
@@ -159,5 +159,5 @@ var (
 		Subsystem: "analytics",
 		Name:      "analytics_requests_count",
 		Help:      "Total number of analytics streaming requests received",
-	}, []string{"org", "env", "status"})
+	}, []string{"org", "status"})
 )

--- a/server/authorization.go
+++ b/server/authorization.go
@@ -62,9 +62,10 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *envoy_auth.Check
 				env,
 			}
 		} else {
+			tracker := prometheusRequestTracker(rootContext)
+			defer tracker.record()
 			err := fmt.Errorf("Envoy must be configured to send Apigee env in ContextExtensions[%s] in multitenant mode.", envContextKey)
-			log.Errorf(err.Error())
-			return nil, err
+			return a.internalError(tracker, err), nil
 		}
 	}
 

--- a/server/authorization.go
+++ b/server/authorization.go
@@ -15,18 +15,18 @@
 package server
 
 import (
-	"context"
+	gocontext "context"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
-	aauth "github.com/apigee/apigee-remote-service-golib/auth"
-	libAuth "github.com/apigee/apigee-remote-service-golib/auth"
+	"github.com/apigee/apigee-remote-service-golib/auth"
+	"github.com/apigee/apigee-remote-service-golib/context"
 	"github.com/apigee/apigee-remote-service-golib/log"
 	"github.com/apigee/apigee-remote-service-golib/quota"
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,6 +37,7 @@ import (
 
 const (
 	jwtFilterMetadataKey = "envoy.filters.http.jwt_authn"
+	envContextKey        = "apigee_environment"
 )
 
 // AuthorizationServer server
@@ -46,14 +47,28 @@ type AuthorizationServer struct {
 
 // Register registers
 func (a *AuthorizationServer) Register(s *grpc.Server, handler *Handler) {
-	auth.RegisterAuthorizationServer(s, a)
+	envoy_auth.RegisterAuthorizationServer(s, a)
 	a.handler = handler
 }
 
 // Check does check
-func (a *AuthorizationServer) Check(ctx context.Context, req *auth.CheckRequest) (*auth.CheckResponse, error) {
+func (a *AuthorizationServer) Check(ctx gocontext.Context, req *envoy_auth.CheckRequest) (*envoy_auth.CheckResponse, error) {
 
-	tracker := prometheusRequestTracker(a.handler)
+	var rootContext context.Context = a.handler
+	if a.handler.isMultitenant {
+		if env, override := req.Attributes.ContextExtensions[envContextKey]; override {
+			rootContext = &multitenantContext{
+				a.handler,
+				env,
+			}
+		} else {
+			err := fmt.Errorf("Envoy must be configured to send Apigee env in ContextExtensions[%s] in multitenant mode.", envContextKey)
+			log.Errorf(err.Error())
+			return nil, err
+		}
+	}
+
+	tracker := prometheusRequestTracker(rootContext)
 	defer tracker.record()
 
 	target, ok := req.Attributes.Request.Http.Headers[a.handler.targetHeader]
@@ -97,13 +112,13 @@ func (a *AuthorizationServer) Check(ctx context.Context, req *auth.CheckRequest)
 		}
 	}
 
-	authContext, err := a.handler.authMan.Authenticate(a.handler, apiKey, claims, a.handler.apiKeyClaim)
+	authContext, err := a.handler.authMan.Authenticate(rootContext, apiKey, claims, a.handler.apiKeyClaim)
 	switch err {
-	case libAuth.ErrNoAuth:
+	case auth.ErrNoAuth:
 		return a.unauthorized(tracker), nil
-	case libAuth.ErrBadAuth:
+	case auth.ErrBadAuth:
 		return a.denied(tracker, authContext, target), nil
-	case libAuth.ErrInternalError:
+	case auth.ErrInternalError:
 		return a.internalError(tracker, err), nil
 	}
 
@@ -144,47 +159,47 @@ func (a *AuthorizationServer) Check(ctx context.Context, req *auth.CheckRequest)
 	return a.authOK(tracker, authContext, target), nil
 }
 
-func (a *AuthorizationServer) authOK(tracker *prometheusRequestMetricTracker, authContext *aauth.Context, target string) *auth.CheckResponse {
+func (a *AuthorizationServer) authOK(tracker *prometheusRequestMetricTracker, authContext *auth.Context, target string) *envoy_auth.CheckResponse {
 
 	headers := makeMetadataHeaders(target, authContext)
-	headers = append(headers, &core.HeaderValueOption{
-		Header: &core.HeaderValue{
+	headers = append(headers, &envoy_core.HeaderValueOption{
+		Header: &envoy_core.HeaderValue{
 			Key:   headerAuthorized,
 			Value: "true",
 		},
 	})
 
 	tracker.statusCode = envoy_type.StatusCode_OK
-	return &auth.CheckResponse{
+	return &envoy_auth.CheckResponse{
 		Status: &rpcstatus.Status{
 			Code: int32(rpc.OK),
 		},
-		HttpResponse: &auth.CheckResponse_OkResponse{
-			OkResponse: &auth.OkHttpResponse{
+		HttpResponse: &envoy_auth.CheckResponse_OkResponse{
+			OkResponse: &envoy_auth.OkHttpResponse{
 				Headers: headers,
 			},
 		},
 	}
 }
 
-func (a *AuthorizationServer) unauthorized(tracker *prometheusRequestMetricTracker) *auth.CheckResponse {
+func (a *AuthorizationServer) unauthorized(tracker *prometheusRequestMetricTracker) *envoy_auth.CheckResponse {
 	return a.createDenyResponse(tracker, nil, "", rpc.UNAUTHENTICATED)
 }
 
-func (a *AuthorizationServer) internalError(tracker *prometheusRequestMetricTracker, err error) *auth.CheckResponse {
+func (a *AuthorizationServer) internalError(tracker *prometheusRequestMetricTracker, err error) *envoy_auth.CheckResponse {
 	log.Errorf("sending internal error: %v", err)
 	return a.createDenyResponse(tracker, nil, "", rpc.INTERNAL)
 }
 
-func (a *AuthorizationServer) denied(tracker *prometheusRequestMetricTracker, authContext *aauth.Context, target string) *auth.CheckResponse {
+func (a *AuthorizationServer) denied(tracker *prometheusRequestMetricTracker, authContext *auth.Context, target string) *envoy_auth.CheckResponse {
 	return a.createDenyResponse(tracker, authContext, target, rpc.PERMISSION_DENIED)
 }
 
-func (a *AuthorizationServer) quotaExceeded(tracker *prometheusRequestMetricTracker, authContext *aauth.Context, target string) *auth.CheckResponse {
+func (a *AuthorizationServer) quotaExceeded(tracker *prometheusRequestMetricTracker, authContext *auth.Context, target string) *envoy_auth.CheckResponse {
 	return a.createDenyResponse(tracker, authContext, target, rpc.RESOURCE_EXHAUSTED)
 }
 
-func (a *AuthorizationServer) createDenyResponse(tracker *prometheusRequestMetricTracker, authContext *aauth.Context, target string, code rpc.Code) *auth.CheckResponse {
+func (a *AuthorizationServer) createDenyResponse(tracker *prometheusRequestMetricTracker, authContext *auth.Context, target string, code rpc.Code) *envoy_auth.CheckResponse {
 
 	// use intended code, not OK
 	switch code {
@@ -204,7 +219,7 @@ func (a *AuthorizationServer) createDenyResponse(tracker *prometheusRequestMetri
 	if a.handler.rejectUnauthorized || authContext == nil { // send reject to client
 		log.Debugf("sending denied: %s", code.String())
 
-		response := &auth.CheckResponse{
+		response := &envoy_auth.CheckResponse{
 			Status: &rpcstatus.Status{
 				Code: int32(code),
 			},
@@ -212,8 +227,8 @@ func (a *AuthorizationServer) createDenyResponse(tracker *prometheusRequestMetri
 
 		// Envoy doesn't automatically map this code, force it
 		if code == rpc.RESOURCE_EXHAUSTED {
-			response.HttpResponse = &auth.CheckResponse_DeniedResponse{
-				DeniedResponse: &auth.DeniedHttpResponse{
+			response.HttpResponse = &envoy_auth.CheckResponse_DeniedResponse{
+				DeniedResponse: &envoy_auth.DeniedHttpResponse{
 					Status: &envoy_type.HttpStatus{
 						Code: tracker.statusCode,
 					},
@@ -226,12 +241,12 @@ func (a *AuthorizationServer) createDenyResponse(tracker *prometheusRequestMetri
 
 	// allow request to continue upstream
 	log.Debugf("sending ok (actual: %s)", code.String())
-	return &auth.CheckResponse{
+	return &envoy_auth.CheckResponse{
 		Status: &rpcstatus.Status{
 			Code: int32(rpc.OK),
 		},
-		HttpResponse: &auth.CheckResponse_OkResponse{
-			OkResponse: &auth.OkHttpResponse{
+		HttpResponse: &envoy_auth.CheckResponse_OkResponse{
+			OkResponse: &envoy_auth.OkHttpResponse{
 				Headers: makeMetadataHeaders(target, authContext),
 			},
 		},
@@ -249,17 +264,17 @@ var (
 )
 
 type prometheusRequestMetricTracker struct {
-	handler    *Handler
-	startTime  time.Time
-	statusCode envoy_type.StatusCode
+	rootContext context.Context
+	startTime   time.Time
+	statusCode  envoy_type.StatusCode
 }
 
 // set statusCode before calling record()
-func prometheusRequestTracker(h *Handler) *prometheusRequestMetricTracker {
+func prometheusRequestTracker(rootContext context.Context) *prometheusRequestMetricTracker {
 	return &prometheusRequestMetricTracker{
-		handler:    h,
-		startTime:  time.Now(),
-		statusCode: envoy_type.StatusCode_InternalServerError,
+		rootContext: rootContext,
+		startTime:   time.Now(),
+		statusCode:  envoy_type.StatusCode_InternalServerError,
 	}
 }
 
@@ -267,5 +282,14 @@ func prometheusRequestTracker(h *Handler) *prometheusRequestMetricTracker {
 func (t *prometheusRequestMetricTracker) record() {
 	codeLabel := fmt.Sprintf("%d", t.statusCode)
 	httpDuration := time.Since(t.startTime)
-	prometheusAuthSeconds.WithLabelValues(t.handler.orgName, t.handler.envName, codeLabel).Observe(httpDuration.Seconds())
+	prometheusAuthSeconds.WithLabelValues(t.rootContext.Organization(), t.rootContext.Environment(), codeLabel).Observe(httpDuration.Seconds())
+}
+
+type multitenantContext struct {
+	*Handler
+	env string
+}
+
+func (o *multitenantContext) Environment() string {
+	return o.env
 }

--- a/server/config.go
+++ b/server/config.go
@@ -27,10 +27,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apigee/apigee-remote-service-golib/log"
 	"github.com/hashicorp/go-multierror"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/pkg/errors"
-	"github.com/prometheus/common/log"
 	"golang.org/x/oauth2/google"
 	"gopkg.in/yaml.v3"
 )
@@ -130,6 +130,10 @@ type TenantConfig struct {
 	JWKS                   *jwk.Set        `yaml:"-" json:"-"`
 	InternalJWTDuration    time.Duration   `yaml:"-" json:"-"`
 	InternalJWTRefresh     time.Duration   `yaml:"-" json:"-"`
+}
+
+func (t *TenantConfig) IsMultitenant() bool {
+	return t.EnvName == "*"
 }
 
 // ProductsConfig is products-related config

--- a/server/handler.go
+++ b/server/handler.go
@@ -46,6 +46,7 @@ type Handler struct {
 	targetHeader       string
 	rejectUnauthorized bool
 	jwtProviderKey     string
+	isMultitenant      bool
 
 	productMan   product.Manager
 	authMan      auth.Manager
@@ -86,7 +87,7 @@ func (h *Handler) Organization() string {
 	return h.orgName
 }
 
-// Environment is the tenant environment
+// Environment is the tenant environment (or "*" for multitenant)
 func (h *Handler) Environment() string {
 	return h.envName
 }
@@ -144,7 +145,6 @@ func NewHandler(config *Config) (*Handler, error) {
 		Client:              instrumentedClientFor(config, "auth", tr),
 		APIKeyCacheDuration: config.Auth.APIKeyCacheDuration,
 		Org:                 config.Tenant.OrgName,
-		Env:                 config.Tenant.EnvName,
 	})
 	if err != nil {
 		return nil, err
@@ -154,7 +154,6 @@ func NewHandler(config *Config) (*Handler, error) {
 		BaseURL: remoteServiceAPI,
 		Client:  instrumentedClientFor(config, "quotas", tr),
 		Org:     config.Tenant.OrgName,
-		Env:     config.Tenant.EnvName,
 	})
 	if err != nil {
 		return nil, err
@@ -210,6 +209,7 @@ func NewHandler(config *Config) (*Handler, error) {
 		targetHeader:       config.Auth.TargetHeader,
 		rejectUnauthorized: config.Auth.RejectUnauthorized,
 		jwtProviderKey:     config.Auth.JWTProviderKey,
+		isMultitenant:      config.Tenant.IsMultitenant(),
 	}
 
 	return h, nil

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -36,7 +36,7 @@ func TestNewHandler(t *testing.T) {
 		InternalAPI:            "http://localhost/remote-service",
 		RemoteServiceAPI:       "http://localhost/remote-service",
 		OrgName:                "org",
-		EnvName:                "env",
+		EnvName:                "*",
 		AllowUnverifiedSSLCert: true,
 		PrivateKeyID:           kid,
 		PrivateKey:             privateKey,

--- a/server/header_context_test.go
+++ b/server/header_context_test.go
@@ -83,16 +83,22 @@ func TestMetadataHeadersExceptions(t *testing.T) {
 	}
 
 	h := &Handler{
-		orgName:       "org",
-		envName:       "*",
-		isMultitenant: true,
+		orgName: "org",
+		envName: "*",
 	}
 	h.targetHeader = "target"
 	header := map[string]string{
 		"target":          "target",
 		headerEnvironment: "test",
 	}
+
 	api, ac := h.decodeMetadataHeaders(header)
+	if ac.Environment() != "*" {
+		t.Errorf("got: %s, want: %s", ac.Environment(), "*")
+	}
+
+	h.isMultitenant = true
+	api, ac = h.decodeMetadataHeaders(header)
 	if api != "target" {
 		t.Errorf("got: %s, want: %s", api, "target")
 	}

--- a/server/header_context_test.go
+++ b/server/header_context_test.go
@@ -26,9 +26,13 @@ import (
 
 func TestMetadataHeaders(t *testing.T) {
 	var opts []*core.HeaderValueOption
-	h := &Handler{
-		orgName: "org",
-		envName: "env",
+	h := &multitenantContext{
+		&Handler{
+			orgName:       "org",
+			envName:       "*",
+			isMultitenant: true,
+		},
+		"env",
 	}
 	authContext := &auth.Context{
 		Context:        h,
@@ -79,11 +83,15 @@ func TestMetadataHeadersExceptions(t *testing.T) {
 	}
 
 	h := &Handler{
-		orgName: "org",
-		envName: "env",
+		orgName:       "org",
+		envName:       "*",
+		isMultitenant: true,
 	}
 	h.targetHeader = "target"
-	header := map[string]string{"target": "target"}
+	header := map[string]string{
+		"target":          "target",
+		headerEnvironment: "test",
+	}
 	api, ac := h.decodeMetadataHeaders(header)
 	if api != "target" {
 		t.Errorf("got: %s, want: %s", api, "target")
@@ -91,8 +99,8 @@ func TestMetadataHeadersExceptions(t *testing.T) {
 	if ac.Organization() != h.orgName {
 		t.Errorf("got: %s, want: %s", ac.Organization(), h.orgName)
 	}
-	if ac.Environment() != h.envName {
-		t.Errorf("got: %s, want: %s", ac.Environment(), h.envName)
+	if ac.Environment() != "test" {
+		t.Errorf("got: %s, want: %s", ac.Environment(), "test")
 	}
 
 	h.targetHeader = "missing"

--- a/server/header_context_test.go
+++ b/server/header_context_test.go
@@ -96,6 +96,9 @@ func TestMetadataHeadersExceptions(t *testing.T) {
 	if ac.Environment() != "*" {
 		t.Errorf("got: %s, want: %s", ac.Environment(), "*")
 	}
+	if api != "target" {
+		t.Errorf("got: %s, want: %s", api, "target")
+	}
 
 	h.isMultitenant = true
 	api, ac = h.decodeMetadataHeaders(header)


### PR DESCRIPTION
accepts `"*"` as `tenant.env_name` to put it multitenant mode
requires change: https://github.com/apigee/apigee-remote-service-cli/issues/149

For multitenant, Envoy configuration requires the addition of a segment like this to Envoy's `virtual_host` or `route` to specify an environment for ext_authz:
```
                typed_per_filter_config:
                  envoy.filters.http.ext_authz:
                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                    check_settings:
                      context_extensions:
                        apigee_environment: test
```