### PR TITLE
added mtls support

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -116,19 +116,19 @@ type TLSClientConfig struct {
 
 // TenantConfig is config relating to an Apigee tentant
 type TenantConfig struct {
-	InternalAPI            string          `yaml:"internal_api,omitempty" json:"internal_api,omitempty"`
-	RemoteServiceAPI       string          `yaml:"remote_service_api" json:"remote_service_api"`
-	OrgName                string          `yaml:"org_name" json:"org_name"`
-	EnvName                string          `yaml:"env_name" json:"env_name"`
-	Key                    string          `yaml:"key,omitempty" json:"key,omitempty"`
-	Secret                 string          `yaml:"secret,omitempty" json:"secret,omitempty"`
-	ClientTimeout          time.Duration   `yaml:"client_timeout,omitempty" json:"client_timeout,omitempty"`
-	AllowUnverifiedSSLCert bool            `yaml:"allow_unverified_ssl_cert,omitempty" json:"allow_unverified_ssl_cert,omitempty"`
-	PrivateKey             *rsa.PrivateKey `yaml:"-" json:"-"`
-	PrivateKeyID           string          `yaml:"-" json:"-"`
-	JWKS                   *jwk.Set        `yaml:"-" json:"-"`
-	InternalJWTDuration    time.Duration   `yaml:"-" json:"-"`
-	InternalJWTRefresh     time.Duration   `yaml:"-" json:"-"`
+	InternalAPI         string          `yaml:"internal_api,omitempty" json:"internal_api,omitempty"`
+	RemoteServiceAPI    string          `yaml:"remote_service_api" json:"remote_service_api"`
+	OrgName             string          `yaml:"org_name" json:"org_name"`
+	EnvName             string          `yaml:"env_name" json:"env_name"`
+	Key                 string          `yaml:"key,omitempty" json:"key,omitempty"`
+	Secret              string          `yaml:"secret,omitempty" json:"secret,omitempty"`
+	ClientTimeout       time.Duration   `yaml:"client_timeout,omitempty" json:"client_timeout,omitempty"`
+	TLS                 TLSClientConfig `yaml:"tls,omitempty" json:"tls,omitempty"`
+	PrivateKey          *rsa.PrivateKey `yaml:"-" json:"-"`
+	PrivateKeyID        string          `yaml:"-" json:"-"`
+	JWKS                *jwk.Set        `yaml:"-" json:"-"`
+	InternalJWTDuration time.Duration   `yaml:"-" json:"-"`
+	InternalJWTRefresh  time.Duration   `yaml:"-" json:"-"`
 }
 
 func (t *TenantConfig) IsMultitenant() bool {

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -16,8 +16,18 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path"
 	"testing"
+	"time"
 
 	"github.com/apigee/apigee-remote-service-envoy/testutil"
 	"golang.org/x/oauth2/google"
@@ -33,18 +43,18 @@ func TestNewHandler(t *testing.T) {
 
 	config := DefaultConfig()
 	config.Tenant = TenantConfig{
-		InternalAPI:            "http://localhost/remote-service",
-		RemoteServiceAPI:       "http://localhost/remote-service",
-		OrgName:                "org",
-		EnvName:                "*",
-		AllowUnverifiedSSLCert: true,
-		PrivateKeyID:           kid,
-		PrivateKey:             privateKey,
+		InternalAPI:      "http://localhost/remote-service",
+		RemoteServiceAPI: "http://localhost/remote-service",
+		OrgName:          "org",
+		EnvName:          "*",
+		PrivateKeyID:     kid,
+		PrivateKey:       privateKey,
 	}
 	config.Auth = AuthConfig{
-		APIKeyClaim:  "claim",
-		APIKeyHeader: "header",
-		APIHeader:    "api",
+		APIKeyClaim:       "claim",
+		APIKeyHeader:      "header",
+		APIHeader:         "api",
+		AllowUnauthorized: true,
 	}
 
 	h, err := NewHandler(config)
@@ -86,9 +96,6 @@ func TestNewHandler(t *testing.T) {
 	}
 	if h.apiHeader != config.Auth.APIHeader {
 		t.Errorf("got: %s, want: %s", h.apiHeader, config.Auth.APIHeader)
-	}
-	if h.allowUnauthorized != config.Auth.AllowUnauthorized {
-		t.Errorf("got: %t, want: %t", h.allowUnauthorized, config.Auth.AllowUnauthorized)
 	}
 
 	config.Tenant.InternalAPI = "not an url"
@@ -137,4 +144,143 @@ func fakeServiceAccount() []byte {
 	"client_x509_cert_url": "https://mock.com/robot/v1/metadata/x509/client%40hi.iam.gserviceaccount.com"
 }`)
 	return sa
+}
+
+func TestNewHandlerWithTLS(t *testing.T) {
+	kid := "kid"
+	privateKey, _, err := testutil.GenerateKeyAndJWKs(kid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pemKey, pemCert, err := generateCert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "tls")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tempDir)
+
+	keyFile := path.Join(tempDir, "key.pem")
+	certFile := path.Join(tempDir, "cert.pem")
+
+	if err := os.WriteFile(keyFile, pemKey, os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(certFile, pemCert, os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
+	config := DefaultConfig()
+	config.Tenant = TenantConfig{
+		InternalAPI:      "http://localhost/remote-service",
+		RemoteServiceAPI: "http://localhost/remote-service",
+		OrgName:          "org",
+		EnvName:          "*",
+		PrivateKeyID:     kid,
+		PrivateKey:       privateKey,
+		TLS: TLSClientConfig{
+			CAFile:                 certFile,
+			CertFile:               certFile,
+			KeyFile:                keyFile,
+			AllowUnverifiedSSLCert: true,
+		},
+	}
+	config.Analytics = AnalyticsConfig{
+		FileLimit:          1024,
+		SendChannelSize:    10,
+		CollectionInterval: 2 * time.Minute,
+		LegacyEndpoint:     true,
+		TLS: TLSClientConfig{
+			CAFile:                 certFile,
+			CertFile:               certFile,
+			KeyFile:                keyFile,
+			AllowUnverifiedSSLCert: true,
+		},
+	}
+	config.Auth = AuthConfig{
+		APIKeyClaim:  "claim",
+		APIKeyHeader: "header",
+		APIHeader:    "api",
+	}
+
+	h, err := NewHandler(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h.InternalAPI().String() != config.Tenant.InternalAPI {
+		t.Errorf("got: %s, want: %s", h.internalAPI, config.Tenant.InternalAPI)
+	}
+	if h.RemoteServiceAPI().String() != config.Tenant.RemoteServiceAPI {
+		t.Errorf("got: %s, want: %s", h.remoteServiceAPI, config.Tenant.RemoteServiceAPI)
+	}
+	if h.Organization() != config.Tenant.OrgName {
+		t.Errorf("got: %s, want: %s", h.Organization(), config.Tenant.OrgName)
+	}
+	if h.Environment() != config.Tenant.EnvName {
+		t.Errorf("got: %s, want: %s", h.Environment(), config.Tenant.EnvName)
+	}
+
+	if h.productMan == nil {
+		t.Errorf("productMan must be populated")
+	}
+	if h.authMan == nil {
+		t.Errorf("authMan must be populated")
+	}
+	if h.analyticsMan == nil {
+		t.Errorf("analyticsMan must be populated")
+	}
+	if h.quotaMan == nil {
+		t.Errorf("quotaMan must be populated")
+	}
+}
+
+func generateCert() ([]byte, []byte, error) {
+	certKeyLength := 2048
+	privateKey, err := rsa.GenerateKey(rand.Reader, certKeyLength)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	publicKey := &privateKey.PublicKey
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Apigee"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBuf := &bytes.Buffer{}
+	if err := pem.Encode(keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privateKeyBytes}); err != nil {
+		return nil, nil, err
+	}
+	certBuf := &bytes.Buffer{}
+	if err := pem.Encode(certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}); err != nil {
+		return nil, nil, err
+	}
+
+	return keyBuf.Bytes(), certBuf.Bytes(), nil
 }


### PR DESCRIPTION
- OPDK only for analytics
- All Apigee platforms for other remote-service endpoints

Analytics mTLS is configured in `server.Config.Analytics.TLS`.
Others is configured in `server.Config.Tenant.TLS` - `AllowUnverifiedSSLCert` is also moved inside.