### PR TITLE
set up go1.16 before golangci-lint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,11 @@ jobs:
       - 
         name: Check out code
         uses: actions/checkout@v1
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - 
         name: Reviewdog Lint
         uses: reviewdog/action-golangci-lint@v1


### PR DESCRIPTION
In the Lint workflow of GitHub Actions, reviewdog has been complaining a few issues that shouldn't be there for go1.16