### PR TITLE
Fix up new Environment configuration schema

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -240,14 +240,14 @@ type EnvironmentConfig struct {
 	// Unique ID of the environment config
 	ID string `yaml:"id" json:"id"`
 
-	// A list of API configs
-	API []APIConfig `yaml:"proxies" json:"proxies"`
+	// A list of API configs.
+	APIs []APIConfig `yaml:"apis" json:"apis"`
 }
 
 // APIConfig contains settings for an individual API.
 type APIConfig struct {
 	// ID of the API, used to match the api_source of API Product Operations.
-	ID string `yaml:"name" json:"name"`
+	ID string `yaml:"id" json:"id"`
 	
 	// Base path for this API.
 	BasePath string `yaml:"base_path,omitempty" json:"base_path,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -240,40 +240,40 @@ type EnvironmentConfig struct {
 	// Unique ID of the environment config
 	ID string `yaml:"id" json:"id"`
 
-	// A list of proxy configs
-	Proxies []ProxyConfig `yaml:"proxies" json:"proxies"`
+	// A list of API configs
+	API []APIConfig `yaml:"proxies" json:"proxies"`
 }
 
-// ProxyConfig has the proxy configuration.
-type ProxyConfig struct {
-	// Name of the Proxy, used to match the api_source of API Product Operations.
-	Name string `yaml:"name" json:"name"`
+// APIConfig contains settings for an individual API.
+type APIConfig struct {
+	// ID of the API, used to match the api_source of API Product Operations.
+	ID string `yaml:"name" json:"name"`
 	
-	// Base path for this Proxy.
+	// Base path for this API.
 	BasePath string `yaml:"base_path,omitempty" json:"base_path,omitempty"`
 
-	// The default authentication requirements for this Proxy.
+	// The default authentication requirements for this API.
 	Authentication AuthenticationRequirement `yaml:"authentication,omitempty" json:"authentication,omitempty"`
 
-	// The default consumer authorization requirements for this Proxy.
+	// The default consumer authorization requirements for this API.
 	ConsumerAuthorization ConsumerAuthorization `yaml:"consumer_authorization,omitempty" json:"consumer_authorization,omitempty"`
 
 	// The default value for the `x-apigee-target` header that will be appended to all allowed requests. 
 	TargetID string `yaml:"target" json:"target"`
 
-	// A list of API Operations, names of which must be unique within the Proxy.
+	// A list of API Operations, names of which must be unique within the API.
 	Operations []APIOperation `yaml:"operations,omitempty" json:"operations,omitempty"`
 }
 
 // An APIOperation associates a set of rules with a set of request matching settings.
 type APIOperation struct {
-	// Name of the API Operation. Unique within a Proxy.
+	// Name of the API Operation. Unique within a API.
 	Name string `yaml:"name" json:"name"`
 
-	// The authentication requirements for thie Operation. If specified, this overrides the default AuthenticationRequirement specified at the Proxy level.
+	// The authentication requirements for thie Operation. If specified, this overrides the default AuthenticationRequirement specified at the API level.
 	Authentication AuthenticationRequirement `yaml:"authentication,omitempty" json:"authentication,omitempty"`
 
-	// The consumer authorization requirement for this Operation. If specified, this overrides the default ConsumerAuthorization specified at the Proxy level.
+	// The consumer authorization requirement for this Operation. If specified, this overrides the default ConsumerAuthorization specified at the API level.
 	ConsumerAuthorization ConsumerAuthorization `yaml:"consumer_authorization,omitempty" json:"consumer_authorization,omitempty"`
 
 	// HTTP matching rules for this Operation. If omitted, this API Operation will match all HTTP requests not matched by another API Operation.
@@ -300,7 +300,8 @@ func (AllAuthenticationRequirements) authenticationRequirement() {}
 
 // JWTAuthentication defines a JWT authentication requirement.
 type JWTAuthentication struct {
-	// Name of this JWT requirement, unique within the Proxy.
+	// Name of this JWT requirement, unique within the 
+	.
 	Name string `yaml:"name" json:"name"`
 
 	// JWT issuer ("iss" claim)

--- a/config/config.go
+++ b/config/config.go
@@ -258,7 +258,7 @@ type ProxyConfig struct {
 	// The default consumer authorization requirements for this Proxy.
 	ConsumerAuthorization ConsumerAuthorization `yaml:"consumer_authorization,omitempty" json:"consumer_authorization,omitempty"`
 
-	// The default target for this Proxy.
+	// The default value for the `x-apigee-target` header that will be appended to all allowed requests. 
 	Target string `yaml:"target" json:"target"`
 
 	// A list of API Operations, names of which must be unique within the Proxy.
@@ -279,7 +279,7 @@ type APIOperation struct {
 	// HTTP matching rules for this Operation. If omitted, this API Operation will match all HTTP requests not matched by another API Operation.
 	HTTPMatches []HTTPMatch `yaml:"http_match,omitempty" json:"http_match,omitempty"`
 
-	// The target for this Operation. If specified, this overrides the default Target specified at the Proxy level.
+	// The value for the `x-apigee-target` header for this Operation that will be appended to all allowed requests. 
 	Target string `yaml:"target,omitempty" json:"target,omitempty"`
 }
 
@@ -317,7 +317,7 @@ type JWTAuthentication struct {
 	ForwardPayloadHeader string `yaml:"forward_payload_header,omitempty" json:"forward_payload_header,omitempty"`
 
 	// Locations where JWT may be found. First match wins.
-	In []HTTPParameter `yaml:"in" json:"in"`
+	In []APIOperationParameter `yaml:"in" json:"in"`
 }
 
 func (JWTAuthentication) authenticationRequirement() {}
@@ -345,7 +345,7 @@ type ConsumerAuthorization struct {
 	FailOpen bool `yaml:"fail_open,omitempty" json:"fail_open,omitempty"`
 
 	// Locations of API consumer credential (API Key). First match wins.
-	In []HTTPParameter `yaml:"in" json:"in"`
+	In []APIOperationParameter `yaml:"in" json:"in"`
 }
 
 // HTTPMatch is an HTTP request matching rule.
@@ -358,9 +358,9 @@ type HTTPMatch struct {
 	Method string `yaml:"method,omitempty" json:"method,omitempty"`
 }
 
-// HTTPParameter defines an HTTP paramter.
-type HTTPParameter struct {
-	// Query, Header and JWTClaim are supported.
+// APIOperationParameter describes an input value to an API Operation.
+type APIOperationParameter struct {
+	// One of Query, Header, or JWTClaim.
 	Match ParamMatch
 
 	// Optional transformation of the parameter value.
@@ -372,12 +372,12 @@ type ParamMatch interface {
 	paramMatch()
 }
 
-// Name of a query paramter
+// Name of an HTTP query string parameter.
 type Query string
 
 func (Query) paramMatch() {}
 
-// Name of a header
+// Name of an HTTP header.
 type Header string
 
 func (Header) paramMatch() {}

--- a/config/config.go
+++ b/config/config.go
@@ -246,6 +246,9 @@ type EnvironmentConfig struct {
 
 // ProxyConfig has the proxy configuration.
 type ProxyConfig struct {
+	// Name of the Proxy, used to match the api_source of API Product Operations.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	
 	// Top-level basepath for the proxy config
 	Basepath string `yaml:"basepath,omitempty" json:"basepath,omitempty"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -146,9 +146,10 @@ type Config struct {
 	Tenant    TenantConfig    `yaml:"tenant,omitempty" json:"tenant,omitempty" mapstructure:"tenant,omitempty"`
 	Products  ProductsConfig  `yaml:"products,omitempty" json:"products,omitempty" mapstructure:"products,omitempty"`
 	Analytics AnalyticsConfig `yaml:"analytics,omitempty" json:"analytics,omitempty" mapstructure:"analytics,omitempty"`
-	// If Environments is specified, APIKeyHeader, APIKeyClaim, JWTProviderKey in AuthConfig will be ineffectual.
+	// If EnvironmentConfigs is specified, APIKeyHeader, APIKeyClaim, JWTProviderKey in AuthConfig will be ineffectual.
 	Auth       AuthConfig `yaml:"auth,omitempty" json:"auth,omitempty" mapstructure:"auth,omitempty"`
-	Environments EnvironmentConfigs `yaml:"environments,omitempty" json:"environments,omitempty" mapstructure:"environments,omitempty"`
+	// Apigee Environment configurations.
+	EnvironmentConfigs EnvironmentConfigs `yaml:"environment_configs,omitempty" json:"environment_configs,omitempty" mapstructure:"environment_configs,omitempty"`
 }
 
 // GlobalConfig is global configuration for the server
@@ -233,9 +234,7 @@ type EnvironmentConfigs struct {
 	Inline []EnvironmentConfig `yaml:"inline,omitempty" json:"inline,omitempty"`
 }
 
-// EnvironmentConfig is an Apigee Environment-level config for
-// Envoy Adapter. It contains a list of operations for the adapter to
-// perform request authentication and authorization.
+// EnvironmentConfig contains a snapshot of the set of API configurations associated with an Apigee Environment.
 type EnvironmentConfig struct {
 	// Unique ID of the environment config
 	ID string `yaml:"id" json:"id"`
@@ -244,7 +243,7 @@ type EnvironmentConfig struct {
 	APIs []APIConfig `yaml:"apis" json:"apis"`
 }
 
-// APIConfig contains settings for an individual API.
+// APIConfig contains authentication, authorization, and transformation settings for a group of API Operations.
 type APIConfig struct {
 	// ID of the API, used to match the api_source of API Product Operations.
 	ID string `yaml:"id" json:"id"`

--- a/config/config.go
+++ b/config/config.go
@@ -247,7 +247,7 @@ type EnvironmentConfig struct {
 // ProxyConfig has the proxy configuration.
 type ProxyConfig struct {
 	// Name of the Proxy, used to match the api_source of API Product Operations.
-	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	Name string `yaml:"name" json:"name"`
 	
 	// Top-level basepath for the proxy config
 	Basepath string `yaml:"basepath,omitempty" json:"basepath,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ type ProxyConfig struct {
 	ConsumerAuthorization ConsumerAuthorization `yaml:"consumer_authorization,omitempty" json:"consumer_authorization,omitempty"`
 
 	// The default value for the `x-apigee-target` header that will be appended to all allowed requests. 
-	Target string `yaml:"target" json:"target"`
+	TargetID string `yaml:"target" json:"target"`
 
 	// A list of API Operations, names of which must be unique within the Proxy.
 	Operations []APIOperation `yaml:"operations,omitempty" json:"operations,omitempty"`
@@ -280,7 +280,7 @@ type APIOperation struct {
 	HTTPMatches []HTTPMatch `yaml:"http_match,omitempty" json:"http_match,omitempty"`
 
 	// The value for the `x-apigee-target` header for this Operation that will be appended to all allowed requests. 
-	Target string `yaml:"target,omitempty" json:"target,omitempty"`
+	TargetID string `yaml:"target,omitempty" json:"target,omitempty"`
 }
 
 // AuthenticationRequirement is the interface defining the authentication requirement.

--- a/config/config.go
+++ b/config/config.go
@@ -146,7 +146,7 @@ type Config struct {
 	Tenant    TenantConfig    `yaml:"tenant,omitempty" json:"tenant,omitempty" mapstructure:"tenant,omitempty"`
 	Products  ProductsConfig  `yaml:"products,omitempty" json:"products,omitempty" mapstructure:"products,omitempty"`
 	Analytics AnalyticsConfig `yaml:"analytics,omitempty" json:"analytics,omitempty" mapstructure:"analytics,omitempty"`
-	// If EnvConfigs is specified, APIKeyHeader, APIKeyClaim, JWTProviderKey in AuthConfig will be ineffectual.
+	// If Environments is specified, APIKeyHeader, APIKeyClaim, JWTProviderKey in AuthConfig will be ineffectual.
 	Auth       AuthConfig `yaml:"auth,omitempty" json:"auth,omitempty" mapstructure:"auth,omitempty"`
 	Environments EnvironmentConfigs `yaml:"environments,omitempty" json:"environments,omitempty" mapstructure:"environments,omitempty"`
 }
@@ -259,10 +259,10 @@ type APIConfig struct {
 	ConsumerAuthorization ConsumerAuthorization `yaml:"consumer_authorization,omitempty" json:"consumer_authorization,omitempty"`
 
 	// The default value for the `x-apigee-target` header that will be appended to all allowed requests. 
-	TargetID string `yaml:"target" json:"target"`
+	TargetID string `yaml:"target,omitempty" json:"target,omitempty"`
 
 	// A list of API Operations, names of which must be unique within the API.
-	Operations []APIOperation `yaml:"operations,omitempty" json:"operations,omitempty"`
+	Operations []APIOperation `yaml:"operations" json:"operations"`
 }
 
 // An APIOperation associates a set of rules with a set of request matching settings.

--- a/config/config.go
+++ b/config/config.go
@@ -300,17 +300,16 @@ func (AllAuthenticationRequirements) authenticationRequirement() {}
 
 // JWTAuthentication defines a JWT authentication requirement.
 type JWTAuthentication struct {
-	// Name of this JWT requirement, unique within the 
-	.
+	// Name of this JWT requirement, unique within the API.
 	Name string `yaml:"name" json:"name"`
 
-	// JWT issuer ("iss" claim)
+	// JWT issuer ("iss" claim).
 	Issuer string `yaml:"issuer" json:"issuer"`
 
-	// The JWKS source
+	// The JWKS source.
 	JWKSSource JWKSSource
 
-	// Audiences contains a list of audiences
+	// Audiences contains a list of audiences.
 	Audiences []string `yaml:"audiences,omitempty" json:"audiences,omitempty"`
 
 	// Header name that will contain decoded JWT payload in requests forwarded to


### PR DESCRIPTION
API Product matching requires an `api_source`. This is currently done using the hostname of the incoming request, however the new Proxy configuration is already associated with an API Proxy, which is semantically the same as `api_source`. This change adds a field to `ProxyConfig` to support this use case.