### PR TITLE
If there are no operations for an api, assume a "match all" operation

### DIFF
--- a/config/env_spec_ext_test.go
+++ b/config/env_spec_ext_test.go
@@ -29,8 +29,8 @@ func TestNewEnvironmentSpecExt(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	if l := len(specExt.JWTAuthentications()); l != 5 {
-		t.Errorf("should be 5 JWTAuthentications, got %d", l)
+	if l := len(specExt.JWTAuthentications()); l != 6 {
+		t.Errorf("should be 6 JWTAuthentications, got %d", l)
 	}
 
 	if specExt.apiPathTree == nil {

--- a/config/env_spec_request_test.go
+++ b/config/env_spec_request_test.go
@@ -146,6 +146,7 @@ func TestGetOperation(t *testing.T) {
 		{"petstore/", http.MethodGet, "/v1/petstore/", petstore},
 		{"petstore with query", http.MethodGet, "/v1/petstore?foo=bar", petstore},
 		{"bookshop", http.MethodPost, "/v1/bookshop/", bookshop},
+		{"noop", http.MethodPost, "/v3/bookshop/", synthesizedOperation},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -319,8 +320,9 @@ func TestIsAuthenticated(t *testing.T) {
 		desc string
 		path string
 	}{
-		{"auth in api", "/v1/petstore"},
-		{"auth in operation", "/v2/petstore"},
+		// {"auth in api", "/v1/petstore"},
+		// {"auth in operation", "/v2/petstore"},
+		{"auth in api, no op", "/v3/petstore"},
 	}
 
 	for _, test := range tests {
@@ -527,3 +529,7 @@ func (a *testAuthMan) Authenticate(ctx context.Context, apiKey string, claims ma
 func (a *testAuthMan) ParseJWT(jwtString string, provider jwt.Provider) (map[string]interface{}, error) {
 	return testutil.MockJWTVerifier{}.Parse(jwtString, provider)
 }
+
+// if operation, do that
+// if operation miss, fail
+// if no operation, do no op

--- a/config/env_spec_request_test.go
+++ b/config/env_spec_request_test.go
@@ -320,8 +320,8 @@ func TestIsAuthenticated(t *testing.T) {
 		desc string
 		path string
 	}{
-		// {"auth in api", "/v1/petstore"},
-		// {"auth in operation", "/v2/petstore"},
+		{"auth in api", "/v1/petstore"},
+		{"auth in operation", "/v2/petstore"},
 		{"auth in api, no op", "/v3/petstore"},
 	}
 
@@ -529,7 +529,3 @@ func (a *testAuthMan) Authenticate(ctx context.Context, apiKey string, claims ma
 func (a *testAuthMan) ParseJWT(jwtString string, provider jwt.Provider) (map[string]interface{}, error) {
 	return testutil.MockJWTVerifier{}.Parse(jwtString, provider)
 }
-
-// if operation, do that
-// if operation miss, fail
-// if no operation, do no op

--- a/config/env_spec_test.go
+++ b/config/env_spec_test.go
@@ -1035,6 +1035,25 @@ func createGoodEnvSpec() EnvironmentSpec {
 					},
 				},
 			},
+			{
+				ID:         "no-operations-api",
+				BasePath:   "/v3",
+				Operations: []APIOperation{},
+				Authentication: AuthenticationRequirement{
+					Requirements: JWTAuthentication{
+						Name:       "foo",
+						Issuer:     "issuer",
+						JWKSSource: RemoteJWKS{URL: "url", CacheDuration: time.Hour},
+						In:         []APIOperationParameter{{Match: Header("jwt")}},
+					},
+				},
+				ConsumerAuthorization: ConsumerAuthorization{
+					In: []APIOperationParameter{
+						{Match: Query("x-api-key")},
+						{Match: Header("x-api-key")},
+					},
+				},
+			},
 		},
 	}}
 	_ = ValidateEnvironmentSpecs(envSpecs)


### PR DESCRIPTION
Fixes #271