### PR TITLE
"Any" semantics for allowed JWT audiences.

### DIFF
--- a/config/env_spec.go
+++ b/config/env_spec.go
@@ -398,7 +398,9 @@ type JWTAuthentication struct {
 	// The JWKS source.
 	JWKSSource JWKSSource `yaml:"-"`
 
-	// Audiences contains a list of audiences.
+	// Audiences contains a list of audiences allowed to access.
+	// A JWT containing any of these audiences will be accepted.
+	// If not specified, the audiences in JWT will not be checked.
 	Audiences []string `yaml:"audiences,omitempty" mapstructure:"audiences,omitempty"`
 
 	// Header name that will contain decoded JWT payload in requests forwarded to

--- a/config/env_spec_ext_test.go
+++ b/config/env_spec_ext_test.go
@@ -29,8 +29,8 @@ func TestNewEnvironmentSpecExt(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	if l := len(specExt.JWTAuthentications()); l != 7 {
-		t.Errorf("should be 7 JWTAuthentications, got %d", l)
+	if l := len(specExt.JWTAuthentications()); l != 8 {
+		t.Errorf("should be 8 JWTAuthentications, got %d", l)
 	}
 
 	if specExt.apiPathTree == nil {

--- a/config/env_spec_request.go
+++ b/config/env_spec_request.go
@@ -264,7 +264,6 @@ func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) bool {
 			}
 			// No intersection exists, break and return false.
 			if err != nil {
-				log.Errorf("jwt aud claim error = %v", err)
 				break
 			}
 		}

--- a/config/env_spec_request.go
+++ b/config/env_spec_request.go
@@ -256,9 +256,16 @@ func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) bool {
 		if err == nil {
 			for _, aud := range jwtReq.Audiences {
 				err = mustBeInClaim(aud, "aud", claims)
-				if err != nil {
+				// Any intersection between allowed audiences and
+				// those in the "aud" claim is accepted.
+				if err == nil {
 					break
 				}
+			}
+			// No intersection exists, break and return false.
+			if err != nil {
+				log.Errorf("jwt aud claim error = %v", err)
+				break
 			}
 		}
 

--- a/config/env_spec_request_test.go
+++ b/config/env_spec_request_test.go
@@ -317,6 +317,7 @@ func TestIsAuthenticated(t *testing.T) {
 	jwtClaims := map[string]interface{}{
 		"key": "value",
 		"iss": "issuer",
+		"aud": []string{"foo", "bar"},
 	}
 	jwtString, err := testutil.GenerateJWT(privateKey, jwtClaims)
 	if err != nil {
@@ -330,6 +331,7 @@ func TestIsAuthenticated(t *testing.T) {
 		{"auth in api", "/v1/petstore"},
 		{"auth in operation", "/v2/petstore"},
 		{"auth in api, no op", "/v3/petstore"},
+		{"auth in operation, aud claim has partial match", "/v1/airport"},
 	}
 
 	for _, test := range tests {
@@ -339,7 +341,7 @@ func TestIsAuthenticated(t *testing.T) {
 			req := NewEnvironmentSpecRequest(&testAuthMan{}, specExt, envoyReq)
 
 			if req.IsAuthenticated() {
-				t.Errorf("IsAuthenticated should be false")
+				t.Fatalf("IsAuthenticated should be false")
 			}
 
 			// internal: err should be cached

--- a/config/env_spec_test.go
+++ b/config/env_spec_test.go
@@ -979,6 +979,28 @@ func createGoodEnvSpec() EnvironmentSpec {
 							},
 						},
 					},
+					{
+						Name: "op-3",
+						HTTPMatches: []HTTPMatch{
+							{
+								PathTemplate: "/airport",
+								Method:       "GET",
+							},
+						},
+						Authentication: AuthenticationRequirement{
+							Requirements: JWTAuthentication{
+								Name:       "foo",
+								Issuer:     "issuer",
+								Audiences:  []string{"foo", "bac"},
+								JWKSSource: RemoteJWKS{URL: "url", CacheDuration: time.Hour},
+								In: []APIOperationParameter{
+									{
+										Match: Header("jwt"),
+									},
+								},
+							},
+						},
+					},
 				},
 				HTTPRequestTransforms: HTTPRequestTransformations{
 					SetHeaders: map[string]string{


### PR DESCRIPTION
Any intersection between the allowed JWT audiences and the aud in the claim will be acceptable.

Fix #301 