### PR TITLE
Append "/" if `opPath` has no "/" as prefix.

### DIFF
--- a/config/env_spec_request.go
+++ b/config/env_spec_request.go
@@ -109,7 +109,10 @@ func (e *EnvironmentSpecRequest) parseRequest() {
 	}
 
 	// trim api base path
-	opPath := strings.TrimPrefix(path, e.apiSpec.BasePath)
+	opPath := path
+	if e.apiSpec.BasePath != "/" {
+		opPath = strings.TrimPrefix(path, e.apiSpec.BasePath)
+	}
 
 	var pathTemplate *transform.Template
 

--- a/config/env_spec_request.go
+++ b/config/env_spec_request.go
@@ -109,9 +109,9 @@ func (e *EnvironmentSpecRequest) parseRequest() {
 	}
 
 	// trim api base path
-	opPath := path
-	if e.apiSpec.BasePath != "/" {
-		opPath = strings.TrimPrefix(path, e.apiSpec.BasePath)
+	opPath := strings.TrimPrefix(path, e.apiSpec.BasePath)
+	if !strings.HasPrefix(opPath, "/") {
+		opPath = "/" + opPath
 	}
 
 	var pathTemplate *transform.Template

--- a/config/env_spec_request_test.go
+++ b/config/env_spec_request_test.go
@@ -613,7 +613,8 @@ func TestVariables(t *testing.T) {
 	envSpec := &EnvironmentSpec{
 		ID: "good-env-config",
 		APIs: []APISpec{{
-			ID: "apispec1",
+			BasePath: "/",
+			ID:       "apispec1",
 			Operations: []APIOperation{{
 				Name: "op",
 				HTTPMatches: []HTTPMatch{{


### PR DESCRIPTION
fix #323 