### PR TITLE
ensure ca-certificates.crt is read only (#326)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN CGO_ENABLED=$CGO_ENABLED go build -a \
 RUN groupadd -g 999 apigee && \
     useradd -r -u 999 -g apigee apigee
 
+# remove all write privileges from ca-certificates.crt
+RUN chmod 4444 /etc/ssl/certs/ca-certificates.crt
+
 #--- Build runtime container ---#
 FROM ${RUN_CONTAINER}
 


### PR DESCRIPTION
Fixes #325 in 2.0.x branch (cherry pick)