### PR TITLE
Add RevisionID to APISpec

### DIFF
--- a/config/env_spec.go
+++ b/config/env_spec.go
@@ -226,7 +226,7 @@ type APISpec struct {
 	ID string `yaml:"id" mapstructure:"id"`
 
 	// RevisionID of the API, used to report the revision of the spec that generated errors.
-	RevisionID string `yaml:"revision_id" mapstructure:"revision_id,omitempty"`
+	RevisionID string `yaml:"revision_id" mapstructure:"revision_id"`
 
 	// Name of the gRPC service provided by this API. Used to map native gRPC method calls.
 	GrpcService string `yaml:"grpc_service,omitempty" mapstructure:"grpc_service,omitempty"`

--- a/config/env_spec.go
+++ b/config/env_spec.go
@@ -225,6 +225,8 @@ type APISpec struct {
 	// ID of the API, used to match the api_source of API Product Operations.
 	ID string `yaml:"id" mapstructure:"id"`
 
+	RevisionID string `yaml:"revision_id" mapstructure:"revision_id,omitempty"`
+
 	// Name of the gRPC service provided by this API. Used to map native gRPC method calls.
 	GrpcService string `yaml:"grpc_service,omitempty" mapstructure:"grpc_service,omitempty"`
 

--- a/config/env_spec.go
+++ b/config/env_spec.go
@@ -225,6 +225,7 @@ type APISpec struct {
 	// ID of the API, used to match the api_source of API Product Operations.
 	ID string `yaml:"id" mapstructure:"id"`
 
+	// RevisionID of the API, used to report the revision of the spec that generated errors.
 	RevisionID string `yaml:"revision_id" mapstructure:"revision_id,omitempty"`
 
 	// Name of the gRPC service provided by this API. Used to map native gRPC method calls.

--- a/config/env_spec_test.go
+++ b/config/env_spec_test.go
@@ -1179,8 +1179,9 @@ func createGoodEnvSpec() EnvironmentSpec {
 		ID: "good-env-config",
 		APIs: []APISpec{
 			{
-				ID:       "apispec1",
-				BasePath: "/v1",
+				ID:         "apispec1",
+				RevisionID: "5",
+				BasePath:   "/v1",
 				Authentication: AuthenticationRequirement{
 					Requirements: AnyAuthenticationRequirements{
 						AuthenticationRequirement{
@@ -1278,8 +1279,9 @@ func createGoodEnvSpec() EnvironmentSpec {
 				},
 			},
 			{
-				ID:       "apispec2",
-				BasePath: "/v2",
+				ID:         "apispec2",
+				RevisionID: "4",
+				BasePath:   "/v2",
 				Authentication: AuthenticationRequirement{
 					Requirements: JWTAuthentication{
 						Name:       "foo",
@@ -1355,6 +1357,7 @@ func createGoodEnvSpec() EnvironmentSpec {
 			},
 			{
 				ID:         "no-operations-api",
+				RevisionID: "3",
 				BasePath:   "/v3",
 				Operations: []APIOperation{},
 				Authentication: AuthenticationRequirement{
@@ -1373,8 +1376,9 @@ func createGoodEnvSpec() EnvironmentSpec {
 				},
 			},
 			{
-				ID:       "empty-operation",
-				BasePath: "/v4/*",
+				ID:         "empty-operation",
+				RevisionID: "2",
+				BasePath:   "/v4/*",
 				Operations: []APIOperation{
 					{
 						Name:        "empty",
@@ -1398,6 +1402,7 @@ func createGoodEnvSpec() EnvironmentSpec {
 			},
 			{
 				ID:          "grpcapispec",
+				RevisionID:  "1",
 				GrpcService: "foo.petstore.PetstoreService",
 				Authentication: AuthenticationRequirement{
 					Requirements: JWTAuthentication{

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,6 @@ require (
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect

--- a/server/authorization.go
+++ b/server/authorization.go
@@ -307,14 +307,15 @@ func (a *AuthorizationServer) createEnvoyForwarded(
 	okResponse.ResponseHeadersToAdd = append(okResponse.ResponseHeadersToAdd, corsResponseHeaders(envRequest)...)
 
 	// apigee dynamic data response headers
-	var basepath string
 	var dynamicDataHeaders []*corev3.HeaderValueOption
 	if envRequest != nil {
-		if envRequest.GetAPISpec() != nil {
-			basepath = envRequest.GetAPISpec().BasePath
+		var apiSpec *config.APISpec
+		if spec := envRequest.GetAPISpec(); spec != nil {
+			apiSpec = spec
 		}
-		dynamicDataHeaders = apigeeDynamicDataHeaders(a.handler.Organization(), a.handler.Environment(), api, basepath, false)
+		dynamicDataHeaders = apigeeDynamicDataHeaders(a.handler.Organization(), a.handler.Environment(), api, apiSpec, false)
 	}
+
 	okResponse.ResponseHeadersToAdd = append(okResponse.ResponseHeadersToAdd, dynamicDataHeaders...)
 
 	if log.DebugEnabled() {
@@ -575,11 +576,11 @@ func (a *AuthorizationServer) createEnvoyDenied(req *authv3.CheckRequest, envReq
 	}
 
 	// apigee dynamic data response headers
-	var basepath string
+	var apiSpec *config.APISpec
 	if envRequest != nil && envRequest.GetAPISpec() != nil {
-		basepath = envRequest.GetAPISpec().BasePath
+		apiSpec = envRequest.GetAPISpec()
 	}
-	dynamicDataHeaders := apigeeDynamicDataHeaders(a.handler.Organization(), a.handler.Environment(), api, basepath, rpcCode == rpc.INTERNAL)
+	dynamicDataHeaders := apigeeDynamicDataHeaders(a.handler.Organization(), a.handler.Environment(), api, apiSpec, rpcCode == rpc.INTERNAL)
 
 	response := &authv3.CheckResponse{
 		Status: &status.Status{


### PR DESCRIPTION
* In order to avoid passing yet more arguments into apigeeDynamicDataHeaders(),
  replace the `basepath` arg with the APISpec as a whole, so that we can pull
  whatever other data we need out of it as we go on.

Closes #357