### PR TITLE
add monitoring related metrics

### DIFF
--- a/server/accesslog.go
+++ b/server/accesslog.go
@@ -103,7 +103,7 @@ func (a *AccessLogServer) StreamAccessLogs(srv als.AccessLogService_StreamAccess
 func (a *AccessLogServer) handleHTTPLogs(msg *als.StreamAccessLogsMessage_HttpLogs) error {
 
 	for _, v := range msg.HttpLogs.GetLogEntry() {
-		// Send prometheus
+		// record for prometheus metrics
 		prometheusProxyRecord(v)
 
 		req := v.GetRequest()


### PR DESCRIPTION
The `:5001/metrics` return will have this:
```
# HELP proxy_latencies Request and response latencies in milliseconds, including proxy overhead and target service time
# TYPE proxy_latencies histogram
proxy_latencies_bucket{method="GET",le="1"} 0
proxy_latencies_bucket{method="GET",le="2"} 1
proxy_latencies_bucket{method="GET",le="5"} 2
proxy_latencies_bucket{method="GET",le="10"} 2
proxy_latencies_bucket{method="GET",le="25"} 2
proxy_latencies_bucket{method="GET",le="50"} 2
proxy_latencies_bucket{method="GET",le="75"} 2
proxy_latencies_bucket{method="GET",le="100"} 2
proxy_latencies_bucket{method="GET",le="250"} 2
proxy_latencies_bucket{method="GET",le="500"} 2
proxy_latencies_bucket{method="GET",le="750"} 2
proxy_latencies_bucket{method="GET",le="1000"} 2
proxy_latencies_bucket{method="GET",le="2500"} 2
proxy_latencies_bucket{method="GET",le="5000"} 2
proxy_latencies_bucket{method="GET",le="7500"} 2
proxy_latencies_bucket{method="GET",le="10000"} 2
proxy_latencies_bucket{method="GET",le="+Inf"} 2
proxy_latencies_sum{method="GET"} 5
proxy_latencies_count{method="GET"} 2
# HELP proxy_request_count Total number of requests received
# TYPE proxy_request_count counter
proxy_request_count{method="GET"} 2
# HELP proxy_response_count Total number of responses sent
# TYPE proxy_response_count counter
proxy_response_count{fault_code="",fault_src="",method="GET",response_code="404"} 2
```

The buckets follow MP's convention as I compared.