### PR TITLE
Update Apigee Fault Codes for ARC

### DIFF
--- a/Dockerfile_releaser
+++ b/Dockerfile_releaser
@@ -23,7 +23,7 @@ FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golan
 ARG GITHUB_TOKEN
 ARG VERSION
 
-RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+RUN go install github.com/goreleaser/goreleaser@latest
 
 WORKDIR /app
 ADD . .

--- a/config/env_spec_request.go
+++ b/config/env_spec_request.go
@@ -449,19 +449,18 @@ func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) error {
 }
 
 func adapterFaultForJwtErr(err error) *fault.AdapterFault {
-	if err == nil {
+	switch {
+	case err == nil:
 		return fault.NewAdapterFault(fault.JwtUnknownException, rpc.UNAUTHENTICATED, 0)
-	}
-
-	if errors.Is(err, ErrUnsupportedJwkSource) {
+	case errors.Is(err, ErrUnsupportedJwkSource):
 		return fault.NewAdapterFault(fault.JwtInvalidToken, rpc.UNAUTHENTICATED, 0)
-	} else if errors.Is(err, ErrMissingIssuerInClaim) {
+	case errors.Is(err, ErrMissingIssuerInClaim):
 		return fault.NewAdapterFault(fault.JwtIssuerMismatch, rpc.UNAUTHENTICATED, 0)
-	} else if errors.Is(err, ErrMissingAudienceInClaim) {
+	case errors.Is(err, ErrMissingAudienceInClaim):
 		return fault.NewAdapterFault(fault.JwtAudienceMismatch, rpc.UNAUTHENTICATED, 0)
-	} else if errors.Is(err, ErrJwtParsingFailure) {
+	case errors.Is(err, ErrJwtParsingFailure):
 		return fault.NewAdapterFault(fault.JwtInvalidToken, rpc.UNAUTHENTICATED, 0)
-	} else {
+	default:
 		return fault.NewAdapterFault(fault.JwtUnknownException, rpc.UNAUTHENTICATED, 0)
 	}
 }

--- a/config/env_spec_request.go
+++ b/config/env_spec_request.go
@@ -22,6 +22,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/apigee/apigee-remote-service-envoy/v2/fault"
 	"github.com/apigee/apigee-remote-service-envoy/v2/transform"
 	"github.com/apigee/apigee-remote-service-golib/v2/auth"
@@ -67,6 +69,18 @@ const (
 var defaultOperation = &APIOperation{
 	Name: "default",
 }
+
+// ErrUnsupportedJwkSoource is raised when unsupported JWK source is encountered
+var ErrUnsupportedJwkSource = errors.New("unsupported JWK Source")
+
+// ErrMissingIssuerInClaim is raised when the required issuer value is missing from the supported claims
+var ErrMissingIssuerInClaim = errors.New("issuer value not in claim")
+
+// ErrMissingAudienceInClaim is raised when the required audience value is missing from the supported claims
+var ErrMissingAudienceInClaim = errors.New("audience value not in claim")
+
+// ErrJwtParsingFailure is raised when JWT Parsing fails
+var ErrJwtParsingFailure = errors.New("jwt parsing failed")
 
 // NewEnvironmentSpecRequest creates a new EnvironmentSpecRequest
 func NewEnvironmentSpecRequest(authMan auth.Manager, e *EnvironmentSpecExt, req *authv3.CheckRequest) *EnvironmentSpecRequest {
@@ -356,7 +370,7 @@ func (e *EnvironmentSpecRequest) JWTAuthentications() []*JWTAuthentication {
 // any error can be in e.jwtResults[name]
 func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) error {
 	if e == nil {
-		return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+		return fault.NewAdapterFault(fault.InternalError, rpc.UNAUTHENTICATED, 0)
 	}
 	var jwtReq *JWTAuthentication
 	if len(e.GetOperation().jwtAuthentications) > 0 {
@@ -366,13 +380,13 @@ func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) error {
 	}
 	if jwtReq == nil {
 		log.Debugf("JWTAuthentication %q not found", name)
-		return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+		return fault.NewAdapterFault(fault.JwtUnknownException, rpc.UNAUTHENTICATED, 0)
 	}
 	if result := e.jwtResults[name]; result != nil { // return from cache
 		if result.err == nil {
 			return nil
 		} else {
-			return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+			return adapterFaultForJwtErr(result.err)
 		}
 	}
 
@@ -389,21 +403,29 @@ func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) error {
 		}
 	}
 
+	var err error
+	var claims map[string]interface{}
 	for _, p := range jwtReq.In {
 		jwksSource, ok := jwtReq.JWKSSource.(RemoteJWKS) // only RemoteJWKS supported for now
 		if !ok {
-			setResult(nil, fmt.Errorf("JWKSSource must be RemoteJWKS, got: %#v", jwtReq.JWKSSource))
+			setResult(nil, fmt.Errorf("%w. JWKSSource must be RemoteJWKS, got: %#v", ErrUnsupportedJwkSource, jwtReq.JWKSSource))
 		}
 		jwtString := e.GetParamValue(p)
 		provider := jwt.Provider{JWKSURL: jwksSource.URL}
 
-		claims, err := e.authMan.ParseJWT(jwtString, provider)
+		claims, err = e.authMan.ParseJWT(jwtString, provider)
+		// If parsing failed, log and wrap the error
+		if err != nil {
+			log.Warnf("error in jwt parsing %v", err)
+			err = errors.Wrap(ErrJwtParsingFailure, err.Error())
+		}
+
 		if err == nil {
-			err = mustBeInClaim(jwtReq.Issuer, "iss", claims)
+			err = mustBeInClaim(jwtReq.Issuer, "iss", claims, ErrMissingIssuerInClaim)
 		}
 		if err == nil {
 			for _, aud := range jwtReq.Audiences {
-				err = mustBeInClaim(aud, "aud", claims)
+				err = mustBeInClaim(aud, "aud", claims, ErrMissingAudienceInClaim)
 				// Any intersection between allowed audiences and
 				// those in the "aud" claim is accepted.
 				if err == nil {
@@ -423,11 +445,29 @@ func (e *EnvironmentSpecRequest) verifyJWTAuthentication(name string) error {
 		}
 	}
 
-	return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+	return adapterFaultForJwtErr(err)
+}
+
+func adapterFaultForJwtErr(err error) *fault.AdapterFault {
+	if err == nil {
+		return fault.NewAdapterFault(fault.JwtUnknownException, rpc.UNAUTHENTICATED, 0)
+	}
+
+	if errors.Is(err, ErrUnsupportedJwkSource) {
+		return fault.NewAdapterFault(fault.JwtInvalidToken, rpc.UNAUTHENTICATED, 0)
+	} else if errors.Is(err, ErrMissingIssuerInClaim) {
+		return fault.NewAdapterFault(fault.JwtIssuerMismatch, rpc.UNAUTHENTICATED, 0)
+	} else if errors.Is(err, ErrMissingAudienceInClaim) {
+		return fault.NewAdapterFault(fault.JwtAudienceMismatch, rpc.UNAUTHENTICATED, 0)
+	} else if errors.Is(err, ErrJwtParsingFailure) {
+		return fault.NewAdapterFault(fault.JwtInvalidToken, rpc.UNAUTHENTICATED, 0)
+	} else {
+		return fault.NewAdapterFault(fault.JwtUnknownException, rpc.UNAUTHENTICATED, 0)
+	}
 }
 
 // returns error if passed value is not in claim as string or []string
-func mustBeInClaim(value, name string, claims map[string]interface{}) error {
+func mustBeInClaim(value, name string, claims map[string]interface{}, errToWrap error) error {
 	if value == "" {
 		return nil
 	}
@@ -443,7 +483,7 @@ func mustBeInClaim(value, name string, claims map[string]interface{}) error {
 			}
 		}
 	}
-	return fmt.Errorf("%q not in claim %q", value, name)
+	return fmt.Errorf("%w. %q not in claim %q", errToWrap, value, name)
 }
 
 // Authenticate returns error if AuthenticationRequirements are not met for the request.
@@ -487,7 +527,7 @@ func (e *EnvironmentSpecRequest) GetHTTPRequestTransforms() (transforms HTTPRequ
 
 func (e *EnvironmentSpecRequest) verifyAuthenticationRequirements(auth AuthenticationRequirement) error {
 	if e == nil {
-		return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+		return fault.NewAdapterFault(fault.InternalError, rpc.UNAUTHENTICATED, 0)
 	}
 	if auth.Requirements == nil || auth.Disabled {
 		return nil
@@ -496,21 +536,24 @@ func (e *EnvironmentSpecRequest) verifyAuthenticationRequirements(auth Authentic
 	case JWTAuthentication:
 		return e.verifyJWTAuthentication(a.Name)
 	case AnyAuthenticationRequirements:
+		var err error
 		for _, r := range []AuthenticationRequirement(a) {
-			if e.verifyAuthenticationRequirements(r) == nil {
+			if err = e.verifyAuthenticationRequirements(r); err == nil {
 				return nil
 			}
 		}
-		return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+		// none of the authentication requirements matched, returning the last error
+		return err
 	case AllAuthenticationRequirements:
 		for _, r := range []AuthenticationRequirement(a) {
-			if e.verifyAuthenticationRequirements(r) != nil {
-				return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+			// returing the first failing authentication requirement
+			if err := e.verifyAuthenticationRequirements(r); err != nil {
+				return err
 			}
 		}
 		return nil
 	default:
-		return fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)
+		return fault.NewAdapterFault(fault.InternalError, rpc.UNAUTHENTICATED, 0)
 	}
 }
 

--- a/fault/fault.go
+++ b/fault/fault.go
@@ -43,6 +43,27 @@ func (f *AdapterFault) Error() string {
 	return fmt.Sprintf("FaultCode:%v, RpcCode:%v, StatusCode:%v", f.FaultCode, f.RpcCode.String(), f.StatusCode.String())
 }
 
+// Is compares the value of adapter fault with the target error and returns a boolean
+func (f *AdapterFault) Is(target error) bool {
+	// nil is typed & nil of type error != nil of type AdapterFault by default
+	if f == nil && target == nil {
+		return true
+	}
+
+	if f == nil || target == nil {
+		return f == target
+	}
+
+	if target, ok := target.(*AdapterFault); ok {
+		if f.FaultCode == target.FaultCode &&
+			f.RpcCode == target.RpcCode &&
+			f.StatusCode == target.StatusCode {
+			return true
+		}
+	}
+	return false
+}
+
 // NewAdapterFaultWithRpcCode creates and returns a new AdapterFault with the provided input RpcCode.
 func NewAdapterFaultWithRpcCode(rpcCode rpc.Code) *AdapterFault {
 	fault := new(AdapterFault)

--- a/fault/fault_codes.go
+++ b/fault/fault_codes.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fault
+
+const (
+	UnknownAPIProxy               = "messaging.runtime.UnknownAPIProxy"
+	UnknownKeyManagementException = "keymanagement.service.UnknownException"
+	InvalidAuthorizationCode      = "keymanagement.service.invalid_request-authorization_code_invalid"
+	InternalError                 = "messaging.runtime.InternalError"
+	NoApiProductMatchFound        = "keymanagement.service.InvalidAPICallAsNoApiProductMatchFound"
+	OperationQuotaExceeded        = "policies.ratelimit.QuotaViolation"
+	InternalQuotaError            = "policies.ratelimit.InternalError"
+	JwtUnknownException           = "steps.jwt.UnknownException"
+	JwtInvalidToken               = "steps.jwt.InvalidToken"
+	JwtIssuerMismatch             = "steps.jwt.JwtIssuerMismatch"
+	JwtAudienceMismatch           = "steps.jwt.JwtAudienceMismatch"
+)

--- a/server/authorization.go
+++ b/server/authorization.go
@@ -523,7 +523,7 @@ func (a *AuthorizationServer) internalQuotaError(req *authv3.CheckRequest, envRe
 
 func (a *AuthorizationServer) handleFault(req *authv3.CheckRequest, envRequest *config.EnvironmentSpecRequest,
 	tracker *prometheusRequestMetricTracker, api string, authContext *auth.Context, err error) *authv3.CheckResponse {
-	log.Errorf("Sending fault %v", err)
+	log.Debugf("Sending fault %v", err)
 	return a.createConditionalEnvoyDenied(req, envRequest, tracker, authContext, api, err)
 }
 

--- a/server/authorization.go
+++ b/server/authorization.go
@@ -123,7 +123,7 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 		apiSpec := envRequest.GetAPISpec()
 		if apiSpec == nil {
 			log.Debugf("api not found for environment spec %s", envSpec.ID)
-			return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFaultWithRpcCode(rpc.NOT_FOUND)), nil
+			return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFault(fault.UnknownAPIProxy, rpc.NOT_FOUND, 0)), nil
 		}
 		api = apiSpec.ID
 		log.Debugf("api: %s", apiSpec.ID)
@@ -136,7 +136,7 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 		operation = envRequest.GetOperation()
 		if operation == nil {
 			log.Debugf("no valid operation found for api %s", apiSpec.ID)
-			return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFaultWithRpcCode(rpc.NOT_FOUND)), nil
+			return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFault(fault.UnknownAPIProxy, rpc.NOT_FOUND, 0)), nil
 		}
 		log.Debugf("operation: %s", operation.Name)
 
@@ -149,7 +149,7 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 			log.Debugf("no authorization requirements")
 			if err := envRequest.PrepareVariables(); err != nil {
 				log.Errorf("failed to populate context variable: %v", err)
-				return a.handleFault(req, envRequest, tracker, api, &auth.Context{Context: rootContext}, fault.NewAdapterFaultWithRpcCode(rpc.PERMISSION_DENIED)), nil
+				return a.handleFault(req, envRequest, tracker, api, &auth.Context{Context: rootContext}, fault.NewAdapterFault(fault.InternalError, rpc.PERMISSION_DENIED, 0)), nil
 			}
 			// Send the root context for limited dynamic metadata.
 			return a.authOK(req, tracker, &auth.Context{Context: rootContext}, api, envRequest), nil
@@ -177,6 +177,7 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 			api, ok = req.Attributes.Request.Http.Headers[a.handler.apiHeader]
 			if !ok {
 				log.Debugf("missing api header %s", a.handler.apiHeader)
+				// Since global authentication is not done for ARC, We need not return an ARC fault code from here
 				return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)), nil
 			}
 			log.Debugf("api from header: %s", api)
@@ -213,13 +214,13 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 			}
 		}
 	}
-
+	// this is actually authorization
 	authContext, err := a.handler.authMan.Authenticate(rootContext, apiKey, claims, a.handler.apiKeyClaim)
 	switch err {
 	case auth.ErrNoAuth:
-		return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFaultWithRpcCode(rpc.UNAUTHENTICATED)), nil
+		return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFault(fault.InvalidAuthorizationCode, rpc.UNAUTHENTICATED, 0)), nil
 	case auth.ErrBadAuth:
-		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFaultWithRpcCode(rpc.PERMISSION_DENIED)), nil
+		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.InvalidAuthorizationCode, rpc.PERMISSION_DENIED, 0)), nil
 	case auth.ErrInternalError:
 		log.Errorf("encountered internal error: %v", err)
 		return a.internalError(req, envRequest, tracker), nil
@@ -228,38 +229,43 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 			log.Debugf("FailOpen on operation: %v", envRequest.GetOperation().Name)
 			if err := envRequest.PrepareVariables(); err != nil {
 				log.Errorf("failed to populate context variable: %v", err)
-				return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFaultWithRpcCode(rpc.PERMISSION_DENIED)), nil
+				return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.InternalError, rpc.PERMISSION_DENIED, 0)), nil
 			}
 			return a.authOK(req, tracker, authContext, api, envRequest), nil
 		} else {
 			return a.internalError(req, envRequest, tracker), nil
 		}
+	case nil:
+		// Do nothing, proceed to the next step if there is no error.
+	default:
+		// Default case ensures that we handle any new key management related errors gracefully.
+		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.InternalError, rpc.UNAUTHENTICATED, 0)), nil
 	}
 
 	if len(authContext.APIProducts) == 0 {
-		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFaultWithRpcCode(rpc.PERMISSION_DENIED)), nil
+		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.NoApiProductMatchFound, rpc.PERMISSION_DENIED, 0)), nil
 	}
 
 	// authorize against products
 	method := req.Attributes.Request.Http.Method
 	authorizedOps := a.handler.productMan.Authorize(authContext, api, path, method)
 	if len(authorizedOps) == 0 {
-		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFaultWithRpcCode(rpc.PERMISSION_DENIED)), nil
+		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.NoApiProductMatchFound, rpc.PERMISSION_DENIED, 0)), nil
 	}
 
 	// apply quotas to matched operations
 	exceeded, quotaError := a.applyQuotas(authorizedOps, authContext)
 	if quotaError != nil {
 		log.Errorf("encountered internal error: %v", quotaError)
-		return a.internalError(req, envRequest, tracker), nil
+		return a.internalQuotaError(req, envRequest, tracker), nil
 	}
 	if exceeded {
-		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFaultWithRpcCode(rpc.RESOURCE_EXHAUSTED)), nil
+		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.OperationQuotaExceeded, rpc.RESOURCE_EXHAUSTED, 0)), nil
 	}
 
 	if err := envRequest.PrepareVariables(); err != nil {
 		log.Errorf("failed to populate context variable: %v", err)
-		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFaultWithRpcCode(rpc.PERMISSION_DENIED)), nil
+		return a.handleFault(req, envRequest, tracker, api, authContext, fault.NewAdapterFault(fault.InternalError, rpc.PERMISSION_DENIED, 0)), nil
 	}
 	return a.authOK(req, tracker, authContext, api, envRequest), nil
 }
@@ -504,11 +510,15 @@ func (a *AuthorizationServer) corsPreflightResponse(
 }
 
 func (a *AuthorizationServer) unavailable(req *authv3.CheckRequest) *authv3.CheckResponse {
-	return a.handleFault(req, nil, nil, "", nil, fault.NewAdapterFaultWithRpcCode(rpc.UNAVAILABLE))
+	return a.handleFault(req, nil, nil, "", nil, fault.NewAdapterFault(fault.InternalError, rpc.UNAVAILABLE, 0))
 }
 
 func (a *AuthorizationServer) internalError(req *authv3.CheckRequest, envRequest *config.EnvironmentSpecRequest, tracker *prometheusRequestMetricTracker) *authv3.CheckResponse {
-	return a.handleFault(req, envRequest, tracker, "", nil, fault.NewAdapterFaultWithRpcCode(rpc.INTERNAL))
+	return a.handleFault(req, envRequest, tracker, "", nil, fault.NewAdapterFault(fault.InternalError, rpc.INTERNAL, 0))
+}
+
+func (a *AuthorizationServer) internalQuotaError(req *authv3.CheckRequest, envRequest *config.EnvironmentSpecRequest, tracker *prometheusRequestMetricTracker) *authv3.CheckResponse {
+	return a.handleFault(req, envRequest, tracker, "", nil, fault.NewAdapterFault(fault.InternalQuotaError, rpc.INTERNAL, 0))
 }
 
 func (a *AuthorizationServer) handleFault(req *authv3.CheckRequest, envRequest *config.EnvironmentSpecRequest,
@@ -528,7 +538,7 @@ func (a *AuthorizationServer) createConditionalEnvoyDenied(
 	adapterFault, ok := err.(*fault.AdapterFault)
 	if !ok {
 		log.Errorf("Could not cast err %v into AdapterFault.", err)
-		a.createEnvoyDenied(req, envRequest, tracker, authContext, api, fault.NewAdapterFaultWithRpcCode(rpc.INTERNAL))
+		a.createEnvoyDenied(req, envRequest, tracker, authContext, api, fault.NewAdapterFault(fault.InternalError, rpc.INTERNAL, 0))
 	}
 
 	statusCode := typev3.StatusCode_Forbidden
@@ -549,7 +559,7 @@ func (a *AuthorizationServer) createConditionalEnvoyDenied(
 	if authContext != nil && a.handler.allowUnauthorized {
 		if err := envRequest.PrepareVariables(); err != nil {
 			log.Errorf("failed to populate context variable: %v", err)
-			return a.createEnvoyDenied(req, envRequest, tracker, authContext, api, fault.NewAdapterFault("", rpc.PERMISSION_DENIED, typev3.StatusCode_Forbidden))
+			return a.createEnvoyDenied(req, envRequest, tracker, authContext, api, fault.NewAdapterFault(fault.UnknownKeyManagementException, rpc.PERMISSION_DENIED, typev3.StatusCode_Forbidden))
 		}
 		log.Debugf("sending ok (actual: %s)", adapterFault.RpcCode.String())
 		return a.createEnvoyForwarded(req, tracker, authContext, api, envRequest)

--- a/server/authorization_test.go
+++ b/server/authorization_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/apigee/apigee-remote-service-envoy/v2/config"
+	"github.com/apigee/apigee-remote-service-envoy/v2/fault"
 	"github.com/apigee/apigee-remote-service-envoy/v2/testutil"
 	"github.com/apigee/apigee-remote-service-golib/v2/analytics"
 	"github.com/apigee/apigee-remote-service-golib/v2/auth"
@@ -1064,7 +1065,7 @@ func TestApigeeFaultHeader(t *testing.T) {
 	if !hasHeaderAdd(resp.GetDeniedResponse().GetHeaders(), headerFaultFlag, "true", false) {
 		t.Errorf("expected response header add: %q", headerFaultFlag)
 	}
-	if !hasHeaderAdd(resp.GetDeniedResponse().GetHeaders(), headerFaultCode, "fault", false) {
+	if !hasHeaderAdd(resp.GetDeniedResponse().GetHeaders(), headerFaultCode, fault.InternalError, false) {
 		t.Errorf("expected response header add: %q", headerFaultCode)
 	}
 	if !hasHeaderAdd(resp.GetDeniedResponse().GetHeaders(), headerFaultRevision, "47", false) {


### PR DESCRIPTION
https://github.com/apigee/apigee-remote-service-envoy/issues/371

Adding x-apigee-fault-code values for key management and JWT based authn and authz as well as other internal errors for ARC.

Notes:
- We cannot get more fine-grained fault-codes for key management yet because of how MP communicates the errors. MP only says [invalid apikey](https://github.com/apigee/apigee-remote-service-cli/blob/master/cmd/provision/proxies/remote-service-gcp/apiproxy/policies/Raise-Fault-Invalid-API-Key.xml). We need to either expand the existing handler or wait for the ACMS apis for getting more details, both of which are beyond the scope of this PR.
- Adding a `default` case to the Key management error `switch-case` as per discussion with @emschwar to ensure new errors in future get handled more gracefully.
- I am not adding / updating the unit tests because looks like we only validate whether the error was raised and not the exact details such as rpc code or fault string for the errors. Let me know if that should change.