### PR TITLE
Add fault code for missing operation error

### DIFF
--- a/fault/fault_codes.go
+++ b/fault/fault_codes.go
@@ -16,6 +16,7 @@ package fault
 
 const (
 	UnknownAPIProxy               = "environment.ApiProxyNotFound"
+	OperationNotFound             = "apiProxy.OperationNotFound"
 	UnknownKeyManagementException = "consumerAuthorization.InternalError"
 	AuthorizationCodeNotFound     = "consumerAuthorization.RequestMissingKey"
 	InvalidAuthorizationCode      = "consumerAuthorization.UnknownKey"

--- a/server/authorization.go
+++ b/server/authorization.go
@@ -136,7 +136,7 @@ func (a *AuthorizationServer) Check(ctx gocontext.Context, req *authv3.CheckRequ
 		operation = envRequest.GetOperation()
 		if operation == nil {
 			log.Debugf("no valid operation found for api %s", apiSpec.ID)
-			return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFault(fault.UnknownAPIProxy, rpc.NOT_FOUND, 0)), nil
+			return a.handleFault(req, envRequest, tracker, api, nil, fault.NewAdapterFault(fault.OperationNotFound, rpc.NOT_FOUND, 0)), nil
 		}
 		log.Debugf("operation: %s", operation.Name)
 

--- a/server/authorization_test.go
+++ b/server/authorization_test.go
@@ -440,7 +440,7 @@ func TestEnvRequestCheck(t *testing.T) {
 			path:        "/v1/missing",
 			statusCode:  int32(rpc.NOT_FOUND),
 			wantHeaders: []string{"x-apigee-fault-code"},
-			wantValues:  []string{fault.UnknownAPIProxy},
+			wantValues:  []string{fault.OperationNotFound},
 			wantAppends: []bool{false},
 			immediateAX: 1,
 		},


### PR DESCRIPTION
We did not separate missing operation from missing API proxy, but it's useful to distinguish these cases.

Ref: #378 