### PR TITLE
Update fault codes

### DIFF
--- a/fault/fault_codes.go
+++ b/fault/fault_codes.go
@@ -20,7 +20,7 @@ const (
 	UnknownKeyManagementException = "consumerAuthorization.InternalError"
 	AuthorizationCodeNotFound     = "consumerAuthorization.RequestMissingKey"
 	InvalidAuthorizationCode      = "consumerAuthorization.UnknownKey"
-	InternalError                 = "apiProxy.InternalError"
+	InternalError                 = "environment.InternalError"
 	NoApiProductMatchFound        = "consumerAuthorization.NoApiProductMatchFound"
 	OperationQuotaExceeded        = "consumerAuthorization.quota.LimitExceeded"
 	InternalQuotaError            = "consumerAuthorization.quota.InternalError"

--- a/server/header_context_test.go
+++ b/server/header_context_test.go
@@ -213,7 +213,7 @@ func TestDynamicDataHeaders(t *testing.T) {
 				headerFaultSource:   "ARC",
 				headerFaultFlag:     "true",
 				headerFaultRevision: revision,
-				headerFaultCode:     "apiProxy.InternalError",
+				headerFaultCode:     "environment.InternalError",
 			},
 		},
 		{


### PR DESCRIPTION
* apiProxy.InternalError => environment.InternalError

This reflects that the ultimate source of the error is not the proxy,
but the environment its config runs in.

Closes: #384 