### PR TITLE
Configure tenant key and secret over env vars

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -64,6 +64,8 @@ func DefaultConfig() *Config {
 			ClientTimeout:       30 * time.Second,
 			InternalJWTDuration: 10 * time.Minute,
 			InternalJWTRefresh:  30 * time.Second,
+			Key:                 os.Getenv("APIGEE_REMOTE_SERVICE_TENANT_KEY"),
+			Secret:              os.Getenv("APIGEE_REMOTE_SERVICE_TENANT_SECRET"),
 		},
 		Products: ProductsConfig{
 			RefreshRate: 2 * time.Minute,


### PR DESCRIPTION
Just a little possibility to set tenant key and secret also over environment variables as we don't want to write the key and secret as plain text into our kubernetes deployment. Hope you agree with it. :) 

PS: Feel free to rename the env vars.